### PR TITLE
Recorder delegate abstraction

### DIFF
--- a/src/SharpAttributeParser.Abstractions/DSemanticArrayRecorder.cs
+++ b/src/SharpAttributeParser.Abstractions/DSemanticArrayRecorder.cs
@@ -1,0 +1,8 @@
+﻿namespace SharpAttributeParser;
+
+using System.Collections.Generic;
+
+/// <summary>Responsible for recording the semantically parsed array-valued argument of a constructor or named parameter.</summary>
+/// <param name="value">The value of the argument.</param>
+/// <returns>A <see cref="bool"/> indicating whether the argument was successfully recorded.</returns>
+public delegate bool DSemanticArrayRecorder(IReadOnlyList<object?>? value);

--- a/src/SharpAttributeParser.Abstractions/DSemanticGenericRecorder.cs
+++ b/src/SharpAttributeParser.Abstractions/DSemanticGenericRecorder.cs
@@ -1,0 +1,11 @@
+﻿namespace SharpAttributeParser;
+
+using Microsoft.CodeAnalysis;
+
+using System;
+
+/// <summary>Responsible for recording the semantically parsed argument of a type parameter.</summary>
+/// <param name="value">The value of the argument.</param>
+/// <returns>A <see cref="bool"/> indicating whether the argument was successfully recorded.</returns>
+/// <exception cref="ArgumentNullException"/>
+public delegate bool DSemanticGenericRecorder(ITypeSymbol value);

--- a/src/SharpAttributeParser.Abstractions/DSemanticSingleRecorder.cs
+++ b/src/SharpAttributeParser.Abstractions/DSemanticSingleRecorder.cs
@@ -1,0 +1,6 @@
+﻿namespace SharpAttributeParser;
+
+/// <summary>Responsible for recording the semantically parsed argument of a constructor or named parameter.</summary>
+/// <param name="value">The value of the argument.</param>
+/// <returns>A <see cref="bool"/> indicating whether the argument was successfully recorded.</returns>
+public delegate bool DSemanticSingleRecorder(object? value);

--- a/src/SharpAttributeParser.Abstractions/DSyntacticArrayRecorder.cs
+++ b/src/SharpAttributeParser.Abstractions/DSyntacticArrayRecorder.cs
@@ -1,0 +1,15 @@
+﻿namespace SharpAttributeParser;
+
+using Microsoft.CodeAnalysis;
+
+using System;
+using System.Collections.Generic;
+
+/// <summary>Responsible for recording the syntactically parsed array-valued argument of a constructor or named parameter.</summary>
+/// <param name="value">The value of the argument.</param>
+/// <param name="collectionLocation">The <see cref="Location"/> of the entire argument.</param>
+/// <param name="elementLocations">The <see cref="Location"/> of the individual elements in the array-valued argument.</param>
+/// <returns>A <see cref="bool"/> indicating whether the argument was successfully recorded.</returns>
+/// <exception cref="ArgumentException"/>
+/// <exception cref="ArgumentNullException"/>
+public delegate bool DSyntacticArrayRecorder(IReadOnlyList<object?>? value, Location collectionLocation, IReadOnlyList<Location> elementLocations);

--- a/src/SharpAttributeParser.Abstractions/DSyntacticGenericRecorder.cs
+++ b/src/SharpAttributeParser.Abstractions/DSyntacticGenericRecorder.cs
@@ -1,0 +1,12 @@
+﻿namespace SharpAttributeParser;
+
+using Microsoft.CodeAnalysis;
+
+using System;
+
+/// <summary>Responsible for recording the syntactically parsed argument of a type parameter.</summary>
+/// <param name="value">The value of the argument.</param>
+/// <param name="location">The <see cref="Location"/> of the argument.</param>
+/// <returns>A <see cref="bool"/> indicating whether the argument was successfully recorded.</returns>
+/// <exception cref="ArgumentNullException"/>
+public delegate bool DSyntacticGenericRecorder(ITypeSymbol value, Location location);

--- a/src/SharpAttributeParser.Abstractions/DSyntacticSingleRecorder.cs
+++ b/src/SharpAttributeParser.Abstractions/DSyntacticSingleRecorder.cs
@@ -1,0 +1,12 @@
+﻿namespace SharpAttributeParser;
+
+using Microsoft.CodeAnalysis;
+
+using System;
+
+/// <summary>Responsible for recording the syntactically parsed argument of a constructor or named parameter.</summary>
+/// <param name="value">The value of the argument.</param>
+/// <param name="location">The <see cref="Location"/> of the argument.</param>
+/// <returns>A <see cref="bool"/> indicating whether the argument was successfully recorded.</returns>
+/// <exception cref="ArgumentNullException"/>
+public delegate bool DSyntacticSingleRecorder(object? value, Location location);

--- a/src/SharpAttributeParser.Abstractions/ISemanticAdapterProvider.cs
+++ b/src/SharpAttributeParser.Abstractions/ISemanticAdapterProvider.cs
@@ -8,116 +8,116 @@ using System.Collections.Generic;
 /// <summary>Provides adapters that may be applied to semantically parsed arguments before they are recorded.</summary>
 public interface ISemanticAdapterProvider
 {
-    /// <summary>Returns <see langword="true"/> for any matching type-parameter.</summary>
+    /// <summary>Records any matching type-parameter, and returns <see langword="true"/>.</summary>
     /// <param name="recorder">Responsible for recording the argument of a type-parameter.</param>
-    /// <returns>A recorder that returns <see langword="true"/> if the parameter name matches a registered name, and which wraps the provided recorder.</returns>
-    public abstract Func<ITypeSymbol, bool> For(Action<ITypeSymbol> recorder);
+    /// <returns>A recorder that returns <see langword="true"/> for any matching type-parameter, and which wraps the provided recorder.</returns>
+    public abstract DSemanticGenericRecorder For(Action<ITypeSymbol> recorder);
 
     /// <summary>Ensures that the argument is of a certain type, <typeparamref name="T"/>, before attempting to record it.</summary>
     /// <typeparam name="T">The expected type of the argument.</typeparam>
     /// <param name="recorder">Reponsible for recording the argument, if it is of type <typeparamref name="T"/>.</param>
     /// <returns>A recorder capable of handling an argument of any type, and which wraps the provided recorder.</returns>
-    public abstract Func<object?, bool> For<T>(Func<T, bool> recorder) where T : notnull;
+    public abstract DSemanticSingleRecorder For<T>(Func<T, bool> recorder) where T : notnull;
 
     /// <summary>Ensures that all elements of the argument are of a certain type, <typeparamref name="T"/>, before attempting to record them.</summary>
     /// <typeparam name="T">The expected type of the elements of the argument.</typeparam>
     /// <param name="recorder">Reponsible for recording the argument, if all elements are of type <typeparamref name="T"/>.</param>
     /// <returns>A recorder capable of handling an argument of any type, and which wraps the provided recorder.</returns>
-    public abstract Func<IReadOnlyList<object?>?, bool> For<T>(Func<IReadOnlyList<T>, bool> recorder) where T : notnull;
+    public abstract DSemanticArrayRecorder For<T>(Func<IReadOnlyList<T>, bool> recorder) where T : notnull;
 
     /// <summary>Ensures that the argument is of a certain type, <typeparamref name="T"/>, before attempting to record it - and returns <see langword="true"/> if this is the case.</summary>
     /// <typeparam name="T">The expected type of the argument.</typeparam>
     /// <param name="recorder">Reponsible for recording the argument, if it is of type <typeparamref name="T"/>.</param>
     /// <returns>A recorder capable of handling an argument of any type, and which wraps the provided recorder.</returns>
-    public abstract Func<object?, bool> For<T>(Action<T> recorder) where T : notnull;
+    public abstract DSemanticSingleRecorder For<T>(Action<T> recorder) where T : notnull;
 
     /// <summary>Ensures that all elements of the argument are of a certain type, <typeparamref name="T"/>, before attempting to record them - and returns <see langword="true"/> if this is the case.</summary>
     /// <typeparam name="T">The expected type of the elements of the argument.</typeparam>
     /// <param name="recorder">Reponsible for recording the argument, if all elements are of type <typeparamref name="T"/>.</param>
     /// <returns>A recorder capable of handling an argument of any type, and which wraps the provided recorder.</returns>
-    public abstract Func<IReadOnlyList<object?>?, bool> For<T>(Action<IReadOnlyList<T>> recorder) where T : notnull;
+    public abstract DSemanticArrayRecorder For<T>(Action<IReadOnlyList<T>> recorder) where T : notnull;
 
     /// <summary>Ensures that the argument is of a certain type, <typeparamref name="T"/>, or <see langword="null"/>, before attempting to record it.</summary>
     /// <typeparam name="T">The expected type of the argument.</typeparam>
     /// <param name="recorder">Responsible for recording the argument, if it is of type <typeparamref name="T"/> or <see langword="null"/>.</param>
     /// <returns>A recorder capable of handling an argument of any type, and which wraps the provided recorder.</returns>
-    public abstract Func<object?, bool> ForNullable<T>(Func<T?, bool> recorder) where T : class;
+    public abstract DSemanticSingleRecorder ForNullable<T>(Func<T?, bool> recorder) where T : class;
 
     /// <summary>Ensures that the argument is of a certain type, <typeparamref name="T"/>, or <see langword="null"/>, before attempting to record it.</summary>
     /// <typeparam name="T">The expected type of the argument.</typeparam>
     /// <param name="recorder">Responsible for recording the argument, if it is of type <typeparamref name="T"/> or <see langword="null"/>.</param>
     /// <returns>A recorder capable of handling an argument of any type, and which wraps the provided recorder.</returns>
-    public abstract Func<object?, bool> ForNullable<T>(Func<T?, bool> recorder) where T : struct;
+    public abstract DSemanticSingleRecorder ForNullable<T>(Func<T?, bool> recorder) where T : struct;
 
     /// <summary>Ensures that all elements of the argument are of a certain type, <typeparamref name="T"/>, or <see langword="null"/>, before attempting to record them.</summary>
     /// <typeparam name="T">The expected type of the elements of the argument.</typeparam>
     /// <param name="recorder">Responsible for recording the argument, if all elements are of type <typeparamref name="T"/> or <see langword="null"/>.</param>
     /// <returns>A recorder capable of handling an argument of any type, and which wraps the provided recorder.</returns>
-    public abstract Func<IReadOnlyList<object?>?, bool> ForNullable<T>(Func<IReadOnlyList<T?>?, bool> recorder) where T : class;
+    public abstract DSemanticArrayRecorder ForNullable<T>(Func<IReadOnlyList<T?>?, bool> recorder) where T : class;
 
     /// <summary>Ensures that all elements of the argument are of a certain type, <typeparamref name="T"/>, or <see langword="null"/>, before attempting to record them.</summary>
     /// <typeparam name="T">The expected type of the elements of the argument.</typeparam>
     /// <param name="recorder">Responsible for recording the argument, if all elements are of type <typeparamref name="T"/> or <see langword="null"/>.</param>
     /// <returns>A recorder capable of handling an argument of any type, and which wraps the provided recorder.</returns>
-    public abstract Func<IReadOnlyList<object?>?, bool> ForNullable<T>(Func<IReadOnlyList<T?>?, bool> recorder) where T : struct;
+    public abstract DSemanticArrayRecorder ForNullable<T>(Func<IReadOnlyList<T?>?, bool> recorder) where T : struct;
 
     /// <summary>Ensures that the argument is of a certain type, <typeparamref name="T"/>, or <see langword="null"/>, before attempting to record it - and returns <see langword="true"/> if this is the case.</summary>
     /// <typeparam name="T">The expected type of the argument.</typeparam>
     /// <param name="recorder">Responsible for recording the argument, if it is of type <typeparamref name="T"/> or <see langword="null"/>.</param>
     /// <returns>A recorder capable of handling an argument of any type, and which wraps the provided recorder.</returns>
-    public abstract Func<object?, bool> ForNullable<T>(Action<T?> recorder) where T : class;
+    public abstract DSemanticSingleRecorder ForNullable<T>(Action<T?> recorder) where T : class;
 
     /// <summary>Ensures that the argument is of a certain type, <typeparamref name="T"/>, or <see langword="null"/>, before attempting to record it - and returns <see langword="true"/> if this is the case.</summary>
     /// <typeparam name="T">The expected type of the argument.</typeparam>
     /// <param name="recorder">Responsible for recording the argument, if it is of type <typeparamref name="T"/> or <see langword="null"/>.</param>
     /// <returns>A recorder capable of handling an argument of any type, and which wraps the provided recorder.</returns>
-    public abstract Func<object?, bool> ForNullable<T>(Action<T?> recorder) where T : struct;
+    public abstract DSemanticSingleRecorder ForNullable<T>(Action<T?> recorder) where T : struct;
 
     /// <summary>Ensures that all elements of the argument are of a certain type, <typeparamref name="T"/>, or <see langword="null"/>, before attempting to record them - and returns <see langword="true"/> if this is the case.</summary>
     /// <typeparam name="T">The expected type of the elements of the argument.</typeparam>
     /// <param name="recorder">Responsible for recording the argument, if all elements are of type <typeparamref name="T"/> or <see langword="null"/>.</param>
     /// <returns>A recorder capable of handling an argument of any type, and which wraps the provided recorder.</returns>
-    public abstract Func<IReadOnlyList<object?>?, bool> ForNullable<T>(Action<IReadOnlyList<T?>?> recorder) where T : class;
+    public abstract DSemanticArrayRecorder ForNullable<T>(Action<IReadOnlyList<T?>?> recorder) where T : class;
 
     /// <summary>Ensures that all elements of the argument are of a certain type, <typeparamref name="T"/>, or <see langword="null"/>, before attempting to record them - and returns <see langword="true"/> if this is the case.</summary>
     /// <typeparam name="T">The expected type of the elements of the argument.</typeparam>
     /// <param name="recorder">Responsible for recording the argument, if all elements are of type <typeparamref name="T"/> or <see langword="null"/>.</param>
     /// <returns>A recorder capable of handling an argument of any type, and which wraps the provided recorder.</returns>
-    public abstract Func<IReadOnlyList<object?>?, bool> ForNullable<T>(Action<IReadOnlyList<T?>?> recorder) where T : struct;
+    public abstract DSemanticArrayRecorder ForNullable<T>(Action<IReadOnlyList<T?>?> recorder) where T : struct;
 
     /// <summary>Ensures that all elements of the argument are of a certain type, <typeparamref name="T"/>, or <see langword="null"/>, before attempting to record them.</summary>
     /// <typeparam name="T">The expected type of the elements of the argument.</typeparam>
     /// <param name="recorder">Responsible for recording the argument, if all elements are of type <typeparamref name="T"/> or <see langword="null"/>.</param>
     /// <returns>A recorder capable of handling an argument of any type, and which wraps the provided recorder.</returns>
-    public abstract Func<IReadOnlyList<object?>?, bool> ForNullableElements<T>(Func<IReadOnlyList<T?>, bool> recorder) where T : class;
+    public abstract DSemanticArrayRecorder ForNullableElements<T>(Func<IReadOnlyList<T?>, bool> recorder) where T : class;
 
     /// <summary>Ensures that all elements of the argument are of a certain type, <typeparamref name="T"/>, or <see langword="null"/>, before attempting to record them.</summary>
     /// <typeparam name="T">The expected type of the elements of the argument.</typeparam>
     /// <param name="recorder">Responsible for recording the argument, if all elements are of type <typeparamref name="T"/> or <see langword="null"/>.</param>
     /// <returns>A recorder capable of handling an argument of any type, and which wraps the provided recorder.</returns>
-    public abstract Func<IReadOnlyList<object?>?, bool> ForNullableElements<T>(Func<IReadOnlyList<T?>, bool> recorder) where T : struct;
+    public abstract DSemanticArrayRecorder ForNullableElements<T>(Func<IReadOnlyList<T?>, bool> recorder) where T : struct;
 
     /// <summary>Ensures that all elements of the argument are of a certain type, <typeparamref name="T"/>, or <see langword="null"/>, before attempting to record them and returns <see langword="true"/> if this is the case.</summary>
     /// <typeparam name="T">The expected type of the elements of the argument.</typeparam>
     /// <param name="recorder">Responsible for recording the argument, if all elements are of type <typeparamref name="T"/> or <see langword="null"/>.</param>
     /// <returns>A recorder capable of handling an argument of any type, and which wraps the provided recorder.</returns>
-    public abstract Func<IReadOnlyList<object?>?, bool> ForNullableElements<T>(Action<IReadOnlyList<T?>> recorder) where T : class;
+    public abstract DSemanticArrayRecorder ForNullableElements<T>(Action<IReadOnlyList<T?>> recorder) where T : class;
 
     /// <summary>Ensures that all elements of the argument are of a certain type, <typeparamref name="T"/>, or <see langword="null"/>, before attempting to record them and returns <see langword="true"/> if this is the case.</summary>
     /// <typeparam name="T">The expected type of the elements of the argument.</typeparam>
     /// <param name="recorder">Responsible for recording the argument, if all elements are of type <typeparamref name="T"/> or <see langword="null"/>.</param>
     /// <returns>A recorder capable of handling an argument of any type, and which wraps the provided recorder.</returns>
-    public abstract Func<IReadOnlyList<object?>?, bool> ForNullableElements<T>(Action<IReadOnlyList<T?>> recorder) where T : struct;
+    public abstract DSemanticArrayRecorder ForNullableElements<T>(Action<IReadOnlyList<T?>> recorder) where T : struct;
 
     /// <summary>Ensures that all elements of the argument are of a certain type, <typeparamref name="T"/>, before attempting to record them.</summary>
     /// <typeparam name="T">The expected type of the elements of the argument.</typeparam>
     /// <param name="recorder">Responsible for recording the argument, if all elements are of type <typeparamref name="T"/>.</param>
     /// <returns>A recorder capable of handling an argument of any type, and which wraps the provided recorder.</returns>
-    public abstract Func<IReadOnlyList<object?>?, bool> ForNullableCollection<T>(Func<IReadOnlyList<T>?, bool> recorder) where T : notnull;
+    public abstract DSemanticArrayRecorder ForNullableCollection<T>(Func<IReadOnlyList<T>?, bool> recorder) where T : notnull;
 
     /// <summary>Ensures that all elements of the argument are of a certain type, <typeparamref name="T"/>, before attempting to record them - and returns <see langword="true"/> if this is the case.</summary>
     /// <typeparam name="T">The expected type of the elements of the argument.</typeparam>
     /// <param name="recorder">Responsible for recording the argument, if all elements are of type <typeparamref name="T"/>.</param>
     /// <returns>A recorder capable of handling an argument of any type, and which wraps the provided recorder.</returns>
-    public abstract Func<IReadOnlyList<object?>?, bool> ForNullableCollection<T>(Action<IReadOnlyList<T>?> recorder) where T : notnull;
+    public abstract DSemanticArrayRecorder ForNullableCollection<T>(Action<IReadOnlyList<T>?> recorder) where T : notnull;
 }

--- a/src/SharpAttributeParser.Abstractions/ISyntacticAdapterProvider.cs
+++ b/src/SharpAttributeParser.Abstractions/ISyntacticAdapterProvider.cs
@@ -11,113 +11,113 @@ public interface ISyntacticAdapterProvider
     /// <summary>Returns <see langword="true"/> for any matching type-parameter.</summary>
     /// <param name="recorder">Responsible for recording the argument of a type-parameter.</param>
     /// <returns>A recorder that returns <see langword="true"/> if the parameter name matches a registered name, and which wraps the provided recorder.</returns>
-    public abstract Func<ITypeSymbol, Location, bool> For(Action<ITypeSymbol, Location> recorder);
+    public abstract DSyntacticGenericRecorder For(Action<ITypeSymbol, Location> recorder);
 
     /// <summary>Ensures that the argument is of a certain type, <typeparamref name="T"/>, before attempting to record it.</summary>
     /// <typeparam name="T">The expected type of the argument.</typeparam>
     /// <param name="recorder">Reponsible for recording the argument, if it is of type <typeparamref name="T"/>.</param>
     /// <returns>A recorder capable of handling an argument of any type, and which wraps the provided recorder.</returns>
-    public abstract Func<object?, Location, bool> For<T>(Func<T, Location, bool> recorder) where T : notnull;
+    public abstract DSyntacticSingleRecorder For<T>(Func<T, Location, bool> recorder) where T : notnull;
 
     /// <summary>Ensures that all elements of the argument are of a certain type, <typeparamref name="T"/>, before attempting to record them.</summary>
     /// <typeparam name="T">The expected type of the elements of the argument.</typeparam>
     /// <param name="recorder">Reponsible for recording the argument, if all elements are of type <typeparamref name="T"/>.</param>
     /// <returns>A recorder capable of handling an argument of any type, and which wraps the provided recorder.</returns>
-    public abstract Func<IReadOnlyList<object?>?, Location, IReadOnlyList<Location>, bool> For<T>(Func<IReadOnlyList<T>, Location, IReadOnlyList<Location>, bool> recorder) where T : notnull;
+    public abstract DSyntacticArrayRecorder For<T>(Func<IReadOnlyList<T>, Location, IReadOnlyList<Location>, bool> recorder) where T : notnull;
 
     /// <summary>Ensures that the argument is of a certain type, <typeparamref name="T"/>, before attempting to record it - and returns <see langword="true"/> if this is the case.</summary>
     /// <typeparam name="T">The expected type of the argument.</typeparam>
     /// <param name="recorder">Reponsible for recording the argument, if it is of type <typeparamref name="T"/>.</param>
     /// <returns>A recorder capable of handling an argument of any type, and which wraps the provided recorder.</returns>
-    public abstract Func<object?, Location, bool> For<T>(Action<T, Location> recorder) where T : notnull;
+    public abstract DSyntacticSingleRecorder For<T>(Action<T, Location> recorder) where T : notnull;
 
     /// <summary>Ensures that all elements of the argument are of a certain type, <typeparamref name="T"/>, before attempting to record them - and returns <see langword="true"/> if this is the case.</summary>
     /// <typeparam name="T">The expected type of the elements of the argument.</typeparam>
     /// <param name="recorder">Reponsible for recording the argument, if all elements are of type <typeparamref name="T"/>.</param>
     /// <returns>A recorder capable of handling an argument of any type, and which wraps the provided recorder.</returns>
-    public abstract Func<IReadOnlyList<object?>?, Location, IReadOnlyList<Location>, bool> For<T>(Action<IReadOnlyList<T>, Location, IReadOnlyList<Location>> recorder) where T : notnull;
+    public abstract DSyntacticArrayRecorder For<T>(Action<IReadOnlyList<T>, Location, IReadOnlyList<Location>> recorder) where T : notnull;
 
     /// <summary>Ensures that the argument is of a certain type, <typeparamref name="T"/>, or <see langword="null"/>, before attempting to record it.</summary>
     /// <typeparam name="T">The expected type of the argument.</typeparam>
     /// <param name="recorder">Responsible for recording the argument, if it is of type <typeparamref name="T"/> or <see langword="null"/>.</param>
     /// <returns>A recorder capable of handling an argument of any type, and which wraps the provided recorder.</returns>
-    public abstract Func<object?, Location, bool> ForNullable<T>(Func<T?, Location, bool> recorder) where T : class;
+    public abstract DSyntacticSingleRecorder ForNullable<T>(Func<T?, Location, bool> recorder) where T : class;
 
     /// <summary>Ensures that the argument is of a certain type, <typeparamref name="T"/>, or <see langword="null"/>, before attempting to record it.</summary>
     /// <typeparam name="T">The expected type of the argument.</typeparam>
     /// <param name="recorder">Responsible for recording the argument, if it is of type <typeparamref name="T"/> or <see langword="null"/>.</param>
     /// <returns>A recorder capable of handling an argument of any type, and which wraps the provided recorder.</returns>
-    public abstract Func<object?, Location, bool> ForNullable<T>(Func<T?, Location, bool> recorder) where T : struct;
+    public abstract DSyntacticSingleRecorder ForNullable<T>(Func<T?, Location, bool> recorder) where T : struct;
 
     /// <summary>Ensures that all elements of the argument are of a certain type, <typeparamref name="T"/>, or <see langword="null"/>, before attempting to record them.</summary>
     /// <typeparam name="T">The expected type of the elements of the argument.</typeparam>
     /// <param name="recorder">Responsible for recording the argument, if all elements are of type <typeparamref name="T"/> or <see langword="null"/>.</param>
     /// <returns>A recorder capable of handling an argument of any type, and which wraps the provided recorder.</returns>
-    public abstract Func<IReadOnlyList<object?>?, Location, IReadOnlyList<Location>, bool> ForNullable<T>(Func<IReadOnlyList<T?>?, Location, IReadOnlyList<Location>, bool> recorder) where T : class;
+    public abstract DSyntacticArrayRecorder ForNullable<T>(Func<IReadOnlyList<T?>?, Location, IReadOnlyList<Location>, bool> recorder) where T : class;
 
     /// <summary>Ensures that all elements of the argument are of a certain type, <typeparamref name="T"/>, or <see langword="null"/>, before attempting to record them.</summary>
     /// <typeparam name="T">The expected type of the elements of the argument.</typeparam>
     /// <param name="recorder">Responsible for recording the argument, if all elements are of type <typeparamref name="T"/> or <see langword="null"/>.</param>
     /// <returns>A recorder capable of handling an argument of any type, and which wraps the provided recorder.</returns>
-    public abstract Func<IReadOnlyList<object?>?, Location, IReadOnlyList<Location>, bool> ForNullable<T>(Func<IReadOnlyList<T?>?, Location, IReadOnlyList<Location>, bool> recorder) where T : struct;
+    public abstract DSyntacticArrayRecorder ForNullable<T>(Func<IReadOnlyList<T?>?, Location, IReadOnlyList<Location>, bool> recorder) where T : struct;
 
     /// <summary>Ensures that the argument is of a certain type, <typeparamref name="T"/>, or <see langword="null"/>, before attempting to record it - and returns <see langword="true"/> if this is the case.</summary>
     /// <typeparam name="T">The expected type of the argument.</typeparam>
     /// <param name="recorder">Responsible for recording the argument, if it is of type <typeparamref name="T"/> or <see langword="null"/>.</param>
     /// <returns>A recorder capable of handling an argument of any type, and which wraps the provided recorder.</returns>
-    public abstract Func<object?, Location, bool> ForNullable<T>(Action<T?, Location> recorder) where T : class;
+    public abstract DSyntacticSingleRecorder ForNullable<T>(Action<T?, Location> recorder) where T : class;
 
     /// <summary>Ensures that the argument is of a certain type, <typeparamref name="T"/>, or <see langword="null"/>, before attempting to record it - and returns <see langword="true"/> if this is the case.</summary>
     /// <typeparam name="T">The expected type of the argument.</typeparam>
     /// <param name="recorder">Responsible for recording the argument, if it is of type <typeparamref name="T"/> or <see langword="null"/>.</param>
     /// <returns>A recorder capable of handling an argument of any type, and which wraps the provided recorder.</returns>
-    public abstract Func<object?, Location, bool> ForNullable<T>(Action<T?, Location> recorder) where T : struct;
+    public abstract DSyntacticSingleRecorder ForNullable<T>(Action<T?, Location> recorder) where T : struct;
 
     /// <summary>Ensures that all elements of the argument are of a certain type, <typeparamref name="T"/>, or <see langword="null"/>, before attempting to record them - and returns <see langword="true"/> if this is the case.</summary>
     /// <typeparam name="T">The expected type of the elements of the argument.</typeparam>
     /// <param name="recorder">Responsible for recording the argument, if all elements are of type <typeparamref name="T"/> or <see langword="null"/>.</param>
     /// <returns>A recorder capable of handling an argument of any type, and which wraps the provided recorder.</returns>
-    public abstract Func<IReadOnlyList<object?>?, Location, IReadOnlyList<Location>, bool> ForNullable<T>(Action<IReadOnlyList<T?>?, Location, IReadOnlyList<Location>> recorder) where T : class;
+    public abstract DSyntacticArrayRecorder ForNullable<T>(Action<IReadOnlyList<T?>?, Location, IReadOnlyList<Location>> recorder) where T : class;
 
     /// <summary>Ensures that all elements of the argument are of a certain type, <typeparamref name="T"/>, or <see langword="null"/>, before attempting to record them - and returns <see langword="true"/> if this is the case.</summary>
     /// <typeparam name="T">The expected type of the elements of the argument.</typeparam>
     /// <param name="recorder">Responsible for recording the argument, if all elements are of type <typeparamref name="T"/> or <see langword="null"/>.</param>
     /// <returns>A recorder capable of handling an argument of any type, and which wraps the provided recorder.</returns>
-    public abstract Func<IReadOnlyList<object?>?, Location, IReadOnlyList<Location>, bool> ForNullable<T>(Action<IReadOnlyList<T?>?, Location, IReadOnlyList<Location>> recorder) where T : struct;
+    public abstract DSyntacticArrayRecorder ForNullable<T>(Action<IReadOnlyList<T?>?, Location, IReadOnlyList<Location>> recorder) where T : struct;
 
     /// <summary>Ensures that all elements of the argument are of a certain type, <typeparamref name="T"/>, or <see langword="null"/>, before attempting to record them.</summary>
     /// <typeparam name="T">The expected type of the elements of the argument.</typeparam>
     /// <param name="recorder">Responsible for recording the argument, if all elements are of type <typeparamref name="T"/> or <see langword="null"/>.</param>
     /// <returns>A recorder capable of handling an argument of any type, and which wraps the provided recorder.</returns>
-    public abstract Func<IReadOnlyList<object?>?, Location, IReadOnlyList<Location>, bool> ForNullableElements<T>(Func<IReadOnlyList<T?>, Location, IReadOnlyList<Location>, bool> recorder) where T : class;
+    public abstract DSyntacticArrayRecorder ForNullableElements<T>(Func<IReadOnlyList<T?>, Location, IReadOnlyList<Location>, bool> recorder) where T : class;
 
     /// <summary>Ensures that all elements of the argument are of a certain type, <typeparamref name="T"/>, or <see langword="null"/>, before attempting to record them.</summary>
     /// <typeparam name="T">The expected type of the elements of the argument.</typeparam>
     /// <param name="recorder">Responsible for recording the argument, if all elements are of type <typeparamref name="T"/> or <see langword="null"/>.</param>
     /// <returns>A recorder capable of handling an argument of any type, and which wraps the provided recorder.</returns>
-    public abstract Func<IReadOnlyList<object?>?, Location, IReadOnlyList<Location>, bool> ForNullableElements<T>(Func<IReadOnlyList<T?>, Location, IReadOnlyList<Location>, bool> recorder) where T : struct;
+    public abstract DSyntacticArrayRecorder ForNullableElements<T>(Func<IReadOnlyList<T?>, Location, IReadOnlyList<Location>, bool> recorder) where T : struct;
 
     /// <summary>Ensures that all elements of the argument are of a certain type, <typeparamref name="T"/>, or <see langword="null"/>, before attempting to record them and returns <see langword="true"/> if this is the case.</summary>
     /// <typeparam name="T">The expected type of the elements of the argument.</typeparam>
     /// <param name="recorder">Responsible for recording the argument, if all elements are of type <typeparamref name="T"/> or <see langword="null"/>.</param>
     /// <returns>A recorder capable of handling an argument of any type, and which wraps the provided recorder.</returns>
-    public abstract Func<IReadOnlyList<object?>?, Location, IReadOnlyList<Location>, bool> ForNullableElements<T>(Action<IReadOnlyList<T?>, Location, IReadOnlyList<Location>> recorder) where T : class;
+    public abstract DSyntacticArrayRecorder ForNullableElements<T>(Action<IReadOnlyList<T?>, Location, IReadOnlyList<Location>> recorder) where T : class;
 
     /// <summary>Ensures that all elements of the argument are of a certain type, <typeparamref name="T"/>, or <see langword="null"/>, before attempting to record them and returns <see langword="true"/> if this is the case.</summary>
     /// <typeparam name="T">The expected type of the elements of the argument.</typeparam>
     /// <param name="recorder">Responsible for recording the argument, if all elements are of type <typeparamref name="T"/> or <see langword="null"/>.</param>
     /// <returns>A recorder capable of handling an argument of any type, and which wraps the provided recorder.</returns>
-    public abstract Func<IReadOnlyList<object?>?, Location, IReadOnlyList<Location>, bool> ForNullableElements<T>(Action<IReadOnlyList<T?>, Location, IReadOnlyList<Location>> recorder) where T : struct;
+    public abstract DSyntacticArrayRecorder ForNullableElements<T>(Action<IReadOnlyList<T?>, Location, IReadOnlyList<Location>> recorder) where T : struct;
 
     /// <summary>Ensures that all elements of the argument are of a certain type, <typeparamref name="T"/>, before attempting to record them.</summary>
     /// <typeparam name="T">The expected type of the elements of the argument.</typeparam>
     /// <param name="recorder">Responsible for recording the argument, if all elements are of type <typeparamref name="T"/>.</param>
     /// <returns>A recorder capable of handling an argument of any type, and which wraps the provided recorder.</returns>
-    public abstract Func<IReadOnlyList<object?>?, Location, IReadOnlyList<Location>, bool> ForNullableCollection<T>(Func<IReadOnlyList<T>?, Location, IReadOnlyList<Location>, bool> recorder) where T : notnull;
+    public abstract DSyntacticArrayRecorder ForNullableCollection<T>(Func<IReadOnlyList<T>?, Location, IReadOnlyList<Location>, bool> recorder) where T : notnull;
 
     /// <summary>Ensures that all elements of the argument are of a certain type, <typeparamref name="T"/>, before attempting to record them - and returns <see langword="true"/> if this is the case.</summary>
     /// <typeparam name="T">The expected type of the elements of the argument.</typeparam>
     /// <param name="recorder">Responsible for recording the argument, if all elements are of type <typeparamref name="T"/>.</param>
     /// <returns>A recorder capable of handling an argument of any type, and which wraps the provided recorder.</returns>
-    public abstract Func<IReadOnlyList<object?>?, Location, IReadOnlyList<Location>, bool> ForNullableCollection<T>(Action<IReadOnlyList<T>?, Location, IReadOnlyList<Location>> recorder) where T : notnull;
+    public abstract DSyntacticArrayRecorder ForNullableCollection<T>(Action<IReadOnlyList<T>?, Location, IReadOnlyList<Location>> recorder) where T : notnull;
 }

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullableCollection_Action.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullableCollection_Action.cs
@@ -317,7 +317,7 @@ public class ForNullableCollection_Action
         public IReadOnlyList<StringComparison>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullableCollection<StringComparison>(RecordStringComparisonArray).Invoke);
         }
@@ -334,7 +334,7 @@ public class ForNullableCollection_Action
         public IReadOnlyList<int>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullableCollection<int>(RecordIntArray).Invoke);
         }
@@ -351,7 +351,7 @@ public class ForNullableCollection_Action
         public IReadOnlyList<string>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullableCollection<string>(RecordStringArray).Invoke);
         }

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullableCollection_Action.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullableCollection_Action.cs
@@ -319,7 +319,7 @@ public class ForNullableCollection_Action
 
         protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullableCollection<StringComparison>(RecordStringComparisonArray).Invoke);
+            yield return ("Value", Adapters.ForNullableCollection<StringComparison>(RecordStringComparisonArray));
         }
 
         private void RecordStringComparisonArray(IReadOnlyList<StringComparison>? value)
@@ -336,7 +336,7 @@ public class ForNullableCollection_Action
 
         protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullableCollection<int>(RecordIntArray).Invoke);
+            yield return ("Value", Adapters.ForNullableCollection<int>(RecordIntArray));
         }
 
         private void RecordIntArray(IReadOnlyList<int>? value)
@@ -353,7 +353,7 @@ public class ForNullableCollection_Action
 
         protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullableCollection<string>(RecordStringArray).Invoke);
+            yield return ("Value", Adapters.ForNullableCollection<string>(RecordStringArray));
         }
 
         private void RecordStringArray(IReadOnlyList<string>? value)

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullableCollection_Func.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullableCollection_Func.cs
@@ -334,7 +334,7 @@ public class ForNullableCollection_Func
 
         protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullableCollection<StringComparison>(RecordStringComparisonArray).Invoke);
+            yield return ("Value", Adapters.ForNullableCollection<StringComparison>(RecordStringComparisonArray));
         }
 
         private bool RecordStringComparisonArray(IReadOnlyList<StringComparison>? value)
@@ -353,7 +353,7 @@ public class ForNullableCollection_Func
 
         protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullableCollection<int>(RecordIntArray).Invoke);
+            yield return ("Value", Adapters.ForNullableCollection<int>(RecordIntArray));
         }
 
         private bool RecordIntArray(IReadOnlyList<int>? value)
@@ -372,7 +372,7 @@ public class ForNullableCollection_Func
 
         protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullableCollection<string>(RecordStringArray).Invoke);
+            yield return ("Value", Adapters.ForNullableCollection<string>(RecordStringArray));
         }
 
         private bool RecordStringArray(IReadOnlyList<string>? value)
@@ -391,7 +391,7 @@ public class ForNullableCollection_Func
 
         protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullableCollection<int>(RecordIntArray).Invoke);
+            yield return ("Value", Adapters.ForNullableCollection<int>(RecordIntArray));
         }
 
         private bool RecordIntArray(IReadOnlyList<int>? value)

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullableCollection_Func.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullableCollection_Func.cs
@@ -332,7 +332,7 @@ public class ForNullableCollection_Func
         public IReadOnlyList<StringComparison>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullableCollection<StringComparison>(RecordStringComparisonArray).Invoke);
         }
@@ -351,7 +351,7 @@ public class ForNullableCollection_Func
         public IReadOnlyList<int>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullableCollection<int>(RecordIntArray).Invoke);
         }
@@ -370,7 +370,7 @@ public class ForNullableCollection_Func
         public IReadOnlyList<string>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullableCollection<string>(RecordStringArray).Invoke);
         }
@@ -389,7 +389,7 @@ public class ForNullableCollection_Func
         public IReadOnlyList<int>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullableCollection<int>(RecordIntArray).Invoke);
         }

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullableElements_Action_Class.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullableElements_Action_Class.cs
@@ -76,7 +76,7 @@ public class ForNullableElements_Action_Class
 
         protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullableElements<string>(RecordStringArray).Invoke);
+            yield return ("Value", Adapters.ForNullableElements<string>(RecordStringArray));
         }
 
         private void RecordStringArray(IReadOnlyList<string?> value)

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullableElements_Action_Class.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullableElements_Action_Class.cs
@@ -74,7 +74,7 @@ public class ForNullableElements_Action_Class
         public IReadOnlyList<string?>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullableElements<string>(RecordStringArray).Invoke);
         }

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullableElements_Action_Struct.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullableElements_Action_Struct.cs
@@ -256,7 +256,7 @@ public class ForNullableElements_Action_Struct
 
         protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullableElements<StringComparison>(RecordStringComparisonArray).Invoke);
+            yield return ("Value", Adapters.ForNullableElements<StringComparison>(RecordStringComparisonArray));
         }
 
         private void RecordStringComparisonArray(IReadOnlyList<StringComparison?> value)
@@ -273,7 +273,7 @@ public class ForNullableElements_Action_Struct
 
         protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullableElements<int>(RecordIntArray).Invoke);
+            yield return ("Value", Adapters.ForNullableElements<int>(RecordIntArray));
         }
 
         private void RecordIntArray(IReadOnlyList<int?> value)

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullableElements_Action_Struct.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullableElements_Action_Struct.cs
@@ -254,7 +254,7 @@ public class ForNullableElements_Action_Struct
         public IReadOnlyList<StringComparison?>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullableElements<StringComparison>(RecordStringComparisonArray).Invoke);
         }
@@ -271,7 +271,7 @@ public class ForNullableElements_Action_Struct
         public IReadOnlyList<int?>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullableElements<int>(RecordIntArray).Invoke);
         }

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullableElements_Func_Class.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullableElements_Func_Class.cs
@@ -89,7 +89,7 @@ public class ForNullableElements_Func_Class
         public IReadOnlyList<string?>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullableElements<string>(RecordStringArray).Invoke);
         }
@@ -108,7 +108,7 @@ public class ForNullableElements_Func_Class
         public IReadOnlyList<string?>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullableElements<string>(RecordStringArray).Invoke);
         }

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullableElements_Func_Class.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullableElements_Func_Class.cs
@@ -91,7 +91,7 @@ public class ForNullableElements_Func_Class
 
         protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullableElements<string>(RecordStringArray).Invoke);
+            yield return ("Value", Adapters.ForNullableElements<string>(RecordStringArray));
         }
 
         private bool RecordStringArray(IReadOnlyList<string?> value)
@@ -110,7 +110,7 @@ public class ForNullableElements_Func_Class
 
         protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullableElements<string>(RecordStringArray).Invoke);
+            yield return ("Value", Adapters.ForNullableElements<string>(RecordStringArray));
         }
 
         private bool RecordStringArray(IReadOnlyList<string?> value)

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullableElements_Func_Struct.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullableElements_Func_Struct.cs
@@ -269,7 +269,7 @@ public class ForNullableElements_Func_Struct
         public IReadOnlyList<StringComparison?>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullableElements<StringComparison>(RecordStringComparisonArray).Invoke);
         }
@@ -288,7 +288,7 @@ public class ForNullableElements_Func_Struct
         public IReadOnlyList<int?>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullableElements<int>(RecordIntArray).Invoke);
         }
@@ -307,7 +307,7 @@ public class ForNullableElements_Func_Struct
         public IReadOnlyList<int?>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullableElements<int>(RecordIntArray).Invoke);
         }

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullableElements_Func_Struct.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullableElements_Func_Struct.cs
@@ -271,7 +271,7 @@ public class ForNullableElements_Func_Struct
 
         protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullableElements<StringComparison>(RecordStringComparisonArray).Invoke);
+            yield return ("Value", Adapters.ForNullableElements<StringComparison>(RecordStringComparisonArray));
         }
 
         private bool RecordStringComparisonArray(IReadOnlyList<StringComparison?> value)
@@ -290,7 +290,7 @@ public class ForNullableElements_Func_Struct
 
         protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullableElements<int>(RecordIntArray).Invoke);
+            yield return ("Value", Adapters.ForNullableElements<int>(RecordIntArray));
         }
 
         private bool RecordIntArray(IReadOnlyList<int?> value)
@@ -309,7 +309,7 @@ public class ForNullableElements_Func_Struct
 
         protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullableElements<int>(RecordIntArray).Invoke);
+            yield return ("Value", Adapters.ForNullableElements<int>(RecordIntArray));
         }
 
         private bool RecordIntArray(IReadOnlyList<int?> value)

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Action_Array_Class.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Action_Array_Class.cs
@@ -75,7 +75,7 @@ public class ForNullable_Action_Array_Class
         public IReadOnlyList<string?>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullable<string>(RecordStringArray).Invoke);
         }

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Action_Array_Class.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Action_Array_Class.cs
@@ -77,7 +77,7 @@ public class ForNullable_Action_Array_Class
 
         protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullable<string>(RecordStringArray).Invoke);
+            yield return ("Value", Adapters.ForNullable<string>(RecordStringArray));
         }
 
         private void RecordStringArray(IReadOnlyList<string?>? value)

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Action_Array_Struct.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Action_Array_Struct.cs
@@ -256,7 +256,7 @@ public class ForNullable_Action_Array_Struct
         public IReadOnlyList<StringComparison?>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullable<StringComparison>(RecordStringComparisonArray).Invoke);
         }
@@ -273,7 +273,7 @@ public class ForNullable_Action_Array_Struct
         public IReadOnlyList<int?>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullable<int>(RecordIntArray).Invoke);
         }

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Action_Array_Struct.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Action_Array_Struct.cs
@@ -258,7 +258,7 @@ public class ForNullable_Action_Array_Struct
 
         protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullable<StringComparison>(RecordStringComparisonArray).Invoke);
+            yield return ("Value", Adapters.ForNullable<StringComparison>(RecordStringComparisonArray));
         }
 
         private void RecordStringComparisonArray(IReadOnlyList<StringComparison?>? value)
@@ -275,7 +275,7 @@ public class ForNullable_Action_Array_Struct
 
         protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullable<int>(RecordIntArray).Invoke);
+            yield return ("Value", Adapters.ForNullable<int>(RecordIntArray));
         }
 
         private void RecordIntArray(IReadOnlyList<int?>? value)

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Action_Single_Class.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Action_Single_Class.cs
@@ -105,7 +105,7 @@ public class ForNullable_Action_Single_Class
         public IReadOnlyList<int>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+        protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
         {
             yield return ("Value", Adapters.ForNullable<IReadOnlyList<int>>(RecordIntArray).Invoke);
         }
@@ -122,7 +122,7 @@ public class ForNullable_Action_Single_Class
         public string? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+        protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
         {
             yield return ("Value", Adapters.ForNullable<string>(RecordString).Invoke);
         }

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Action_Single_Class.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Action_Single_Class.cs
@@ -107,7 +107,7 @@ public class ForNullable_Action_Single_Class
 
         protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
         {
-            yield return ("Value", Adapters.ForNullable<IReadOnlyList<int>>(RecordIntArray).Invoke);
+            yield return ("Value", Adapters.ForNullable<IReadOnlyList<int>>(RecordIntArray));
         }
 
         private void RecordIntArray(IReadOnlyList<int>? value)
@@ -124,7 +124,7 @@ public class ForNullable_Action_Single_Class
 
         protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
         {
-            yield return ("Value", Adapters.ForNullable<string>(RecordString).Invoke);
+            yield return ("Value", Adapters.ForNullable<string>(RecordString));
         }
 
         private void RecordString(string? value)

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Action_Single_Struct.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Action_Single_Struct.cs
@@ -228,7 +228,7 @@ public class ForNullable_Action_Single_Struct
 
         protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
         {
-            yield return ("Value", Adapters.ForNullable<StringComparison>(RecordStringComparison).Invoke);
+            yield return ("Value", Adapters.ForNullable<StringComparison>(RecordStringComparison));
         }
 
         private void RecordStringComparison(StringComparison? value)
@@ -245,7 +245,7 @@ public class ForNullable_Action_Single_Struct
 
         protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
         {
-            yield return ("Value", Adapters.ForNullable<int>(RecordInt).Invoke);
+            yield return ("Value", Adapters.ForNullable<int>(RecordInt));
         }
 
         private void RecordInt(int? value)

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Action_Single_Struct.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Action_Single_Struct.cs
@@ -226,7 +226,7 @@ public class ForNullable_Action_Single_Struct
         public StringComparison? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+        protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
         {
             yield return ("Value", Adapters.ForNullable<StringComparison>(RecordStringComparison).Invoke);
         }
@@ -243,7 +243,7 @@ public class ForNullable_Action_Single_Struct
         public int? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+        protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
         {
             yield return ("Value", Adapters.ForNullable<int>(RecordInt).Invoke);
         }

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Func_Array_Class.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Func_Array_Class.cs
@@ -90,7 +90,7 @@ public class ForNullable_Func_Array_Class
         public IReadOnlyList<string?>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullable<string>(RecordStringArray).Invoke);
         }
@@ -109,7 +109,7 @@ public class ForNullable_Func_Array_Class
         public IReadOnlyList<string?>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullable<string>(RecordStringArray).Invoke);
         }

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Func_Array_Class.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Func_Array_Class.cs
@@ -92,7 +92,7 @@ public class ForNullable_Func_Array_Class
 
         protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullable<string>(RecordStringArray).Invoke);
+            yield return ("Value", Adapters.ForNullable<string>(RecordStringArray));
         }
 
         private bool RecordStringArray(IReadOnlyList<string?>? value)
@@ -111,7 +111,7 @@ public class ForNullable_Func_Array_Class
 
         protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullable<string>(RecordStringArray).Invoke);
+            yield return ("Value", Adapters.ForNullable<string>(RecordStringArray));
         }
 
         private bool RecordStringArray(IReadOnlyList<string?>? value)

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Func_Array_Struct.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Func_Array_Struct.cs
@@ -271,7 +271,7 @@ public class ForNullable_Func_Array_Struct
         public IReadOnlyList<StringComparison?>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullable<StringComparison>(RecordStringComparisonArray).Invoke);
         }
@@ -290,7 +290,7 @@ public class ForNullable_Func_Array_Struct
         public IReadOnlyList<int?>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullable<int>(RecordIntArray).Invoke);
         }
@@ -309,7 +309,7 @@ public class ForNullable_Func_Array_Struct
         public IReadOnlyList<int?>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullable<int>(RecordIntArray).Invoke);
         }

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Func_Array_Struct.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Func_Array_Struct.cs
@@ -273,7 +273,7 @@ public class ForNullable_Func_Array_Struct
 
         protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullable<StringComparison>(RecordStringComparisonArray).Invoke);
+            yield return ("Value", Adapters.ForNullable<StringComparison>(RecordStringComparisonArray));
         }
 
         private bool RecordStringComparisonArray(IReadOnlyList<StringComparison?>? value)
@@ -292,7 +292,7 @@ public class ForNullable_Func_Array_Struct
 
         protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullable<int>(RecordIntArray).Invoke);
+            yield return ("Value", Adapters.ForNullable<int>(RecordIntArray));
         }
 
         private bool RecordIntArray(IReadOnlyList<int?>? value)
@@ -311,7 +311,7 @@ public class ForNullable_Func_Array_Struct
 
         protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullable<int>(RecordIntArray).Invoke);
+            yield return ("Value", Adapters.ForNullable<int>(RecordIntArray));
         }
 
         private bool RecordIntArray(IReadOnlyList<int?>? value)

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Func_Single_Class.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Func_Single_Class.cs
@@ -121,7 +121,7 @@ public class ForNullable_Func_Single_Class
         public IReadOnlyList<int>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+        protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
         {
             yield return ("Value", Adapters.ForNullable<IReadOnlyList<int>>(RecordIntArray).Invoke);
         }
@@ -140,7 +140,7 @@ public class ForNullable_Func_Single_Class
         public string? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+        protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
         {
             yield return ("Value", Adapters.ForNullable<string>(RecordString).Invoke);
         }
@@ -159,7 +159,7 @@ public class ForNullable_Func_Single_Class
         public string? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+        protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
         {
             yield return ("Value", Adapters.ForNullable<string>(RecordString).Invoke);
         }

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Func_Single_Class.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Func_Single_Class.cs
@@ -123,7 +123,7 @@ public class ForNullable_Func_Single_Class
 
         protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
         {
-            yield return ("Value", Adapters.ForNullable<IReadOnlyList<int>>(RecordIntArray).Invoke);
+            yield return ("Value", Adapters.ForNullable<IReadOnlyList<int>>(RecordIntArray));
         }
 
         private bool RecordIntArray(IReadOnlyList<int>? value)
@@ -142,7 +142,7 @@ public class ForNullable_Func_Single_Class
 
         protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
         {
-            yield return ("Value", Adapters.ForNullable<string>(RecordString).Invoke);
+            yield return ("Value", Adapters.ForNullable<string>(RecordString));
         }
 
         private bool RecordString(string? value)
@@ -161,7 +161,7 @@ public class ForNullable_Func_Single_Class
 
         protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
         {
-            yield return ("Value", Adapters.ForNullable<string>(RecordString).Invoke);
+            yield return ("Value", Adapters.ForNullable<string>(RecordString));
         }
 
         private bool RecordString(string? value)

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Func_Single_Struct.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Func_Single_Struct.cs
@@ -241,7 +241,7 @@ public class ForNullable_Func_Single_Struct
         public StringComparison? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+        protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
         {
             yield return ("Value", Adapters.ForNullable<StringComparison>(RecordStringComparison).Invoke);
         }
@@ -260,7 +260,7 @@ public class ForNullable_Func_Single_Struct
         public int? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+        protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
         {
             yield return ("Value", Adapters.ForNullable<int>(RecordInt).Invoke);
         }
@@ -279,7 +279,7 @@ public class ForNullable_Func_Single_Struct
         public int? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+        protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
         {
             yield return ("Value", Adapters.ForNullable<int>(RecordInt).Invoke);
         }

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Func_Single_Struct.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Func_Single_Struct.cs
@@ -243,7 +243,7 @@ public class ForNullable_Func_Single_Struct
 
         protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
         {
-            yield return ("Value", Adapters.ForNullable<StringComparison>(RecordStringComparison).Invoke);
+            yield return ("Value", Adapters.ForNullable<StringComparison>(RecordStringComparison));
         }
 
         private bool RecordStringComparison(StringComparison? value)
@@ -262,7 +262,7 @@ public class ForNullable_Func_Single_Struct
 
         protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
         {
-            yield return ("Value", Adapters.ForNullable<int>(RecordInt).Invoke);
+            yield return ("Value", Adapters.ForNullable<int>(RecordInt));
         }
 
         private bool RecordInt(int? value)
@@ -281,7 +281,7 @@ public class ForNullable_Func_Single_Struct
 
         protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
         {
-            yield return ("Value", Adapters.ForNullable<int>(RecordInt).Invoke);
+            yield return ("Value", Adapters.ForNullable<int>(RecordInt));
         }
 
         private bool RecordInt(int? value)

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/For_Action_Array.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/For_Action_Array.cs
@@ -314,7 +314,7 @@ public class For_Action_Array
         public IReadOnlyList<StringComparison>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.For<StringComparison>(RecordStringComparisonArray).Invoke);
         }
@@ -331,7 +331,7 @@ public class For_Action_Array
         public IReadOnlyList<int>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.For<int>(RecordIntArray).Invoke);
         }
@@ -348,7 +348,7 @@ public class For_Action_Array
         public IReadOnlyList<string>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.For<string>(RecordStringArray).Invoke);
         }

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/For_Action_Array.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/For_Action_Array.cs
@@ -316,7 +316,7 @@ public class For_Action_Array
 
         protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.For<StringComparison>(RecordStringComparisonArray).Invoke);
+            yield return ("Value", Adapters.For<StringComparison>(RecordStringComparisonArray));
         }
 
         private void RecordStringComparisonArray(IReadOnlyList<StringComparison> value)
@@ -333,7 +333,7 @@ public class For_Action_Array
 
         protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.For<int>(RecordIntArray).Invoke);
+            yield return ("Value", Adapters.For<int>(RecordIntArray));
         }
 
         private void RecordIntArray(IReadOnlyList<int> value)
@@ -350,7 +350,7 @@ public class For_Action_Array
 
         protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.For<string>(RecordStringArray).Invoke);
+            yield return ("Value", Adapters.For<string>(RecordStringArray));
         }
 
         private void RecordStringArray(IReadOnlyList<string> value)

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/For_Action_Single.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/For_Action_Single.cs
@@ -316,7 +316,7 @@ public class For_Action_Single
 
         protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
         {
-            yield return ("Value", Adapters.For<StringComparison>(RecordStringComparison).Invoke);
+            yield return ("Value", Adapters.For<StringComparison>(RecordStringComparison));
         }
 
         private void RecordStringComparison(StringComparison value)
@@ -333,7 +333,7 @@ public class For_Action_Single
 
         protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
         {
-            yield return ("Value", Adapters.For<int>(RecordInt).Invoke);
+            yield return ("Value", Adapters.For<int>(RecordInt));
         }
 
         private void RecordInt(int value)
@@ -350,7 +350,7 @@ public class For_Action_Single
 
         protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
         {
-            yield return ("Value", Adapters.For<IReadOnlyList<int>>(RecordIntArray).Invoke);
+            yield return ("Value", Adapters.For<IReadOnlyList<int>>(RecordIntArray));
         }
 
         private void RecordIntArray(IReadOnlyList<int> value)
@@ -367,7 +367,7 @@ public class For_Action_Single
 
         protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
         {
-            yield return ("Value", Adapters.For<string>(RecordString).Invoke);
+            yield return ("Value", Adapters.For<string>(RecordString));
         }
 
         private void RecordString(string value)

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/For_Action_Single.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/For_Action_Single.cs
@@ -314,7 +314,7 @@ public class For_Action_Single
         public StringComparison? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+        protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
         {
             yield return ("Value", Adapters.For<StringComparison>(RecordStringComparison).Invoke);
         }
@@ -331,7 +331,7 @@ public class For_Action_Single
         public int? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+        protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
         {
             yield return ("Value", Adapters.For<int>(RecordInt).Invoke);
         }
@@ -348,7 +348,7 @@ public class For_Action_Single
         public IReadOnlyList<int>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+        protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
         {
             yield return ("Value", Adapters.For<IReadOnlyList<int>>(RecordIntArray).Invoke);
         }
@@ -365,7 +365,7 @@ public class For_Action_Single
         public string? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+        protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
         {
             yield return ("Value", Adapters.For<string>(RecordString).Invoke);
         }

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/For_Func_Array.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/For_Func_Array.cs
@@ -331,7 +331,7 @@ public class For_Func_Array
 
         protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.For<StringComparison>(RecordStringComparisonArray).Invoke);
+            yield return ("Value", Adapters.For<StringComparison>(RecordStringComparisonArray));
         }
 
         private bool RecordStringComparisonArray(IReadOnlyList<StringComparison> value)
@@ -350,7 +350,7 @@ public class For_Func_Array
 
         protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.For<int>(RecordIntArray).Invoke);
+            yield return ("Value", Adapters.For<int>(RecordIntArray));
         }
 
         private bool RecordIntArray(IReadOnlyList<int> value)
@@ -369,7 +369,7 @@ public class For_Func_Array
 
         protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.For<string>(RecordStringArray).Invoke);
+            yield return ("Value", Adapters.For<string>(RecordStringArray));
         }
 
         private bool RecordStringArray(IReadOnlyList<string> value)
@@ -388,7 +388,7 @@ public class For_Func_Array
 
         protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.For<int>(RecordInt).Invoke);
+            yield return ("Value", Adapters.For<int>(RecordInt));
         }
 
         private bool RecordInt(IReadOnlyList<int> value)

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/For_Func_Array.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/For_Func_Array.cs
@@ -329,7 +329,7 @@ public class For_Func_Array
         public IReadOnlyList<StringComparison>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.For<StringComparison>(RecordStringComparisonArray).Invoke);
         }
@@ -348,7 +348,7 @@ public class For_Func_Array
         public IReadOnlyList<int>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.For<int>(RecordIntArray).Invoke);
         }
@@ -367,7 +367,7 @@ public class For_Func_Array
         public IReadOnlyList<string>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.For<string>(RecordStringArray).Invoke);
         }
@@ -386,7 +386,7 @@ public class For_Func_Array
         public IReadOnlyList<int>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.For<int>(RecordInt).Invoke);
         }

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/For_Func_Single.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/For_Func_Single.cs
@@ -329,7 +329,7 @@ public class For_Func_Single
         public StringComparison? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+        protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
         {
             yield return ("Value", Adapters.For<StringComparison>(RecordStringComparison).Invoke);
         }
@@ -348,7 +348,7 @@ public class For_Func_Single
         public int? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+        protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
         {
             yield return ("Value", Adapters.For<int>(RecordInt).Invoke);
         }
@@ -367,7 +367,7 @@ public class For_Func_Single
         public IReadOnlyList<int>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+        protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
         {
             yield return ("Value", Adapters.For<IReadOnlyList<int>>(RecordIntArray).Invoke);
         }
@@ -386,7 +386,7 @@ public class For_Func_Single
         public string? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+        protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
         {
             yield return ("Value", Adapters.For<string>(RecordString).Invoke);
         }
@@ -405,7 +405,7 @@ public class For_Func_Single
         public int? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+        protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
         {
             yield return ("Value", Adapters.For<int>(RecordInt).Invoke);
         }

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/For_Func_Single.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/For_Func_Single.cs
@@ -331,7 +331,7 @@ public class For_Func_Single
 
         protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
         {
-            yield return ("Value", Adapters.For<StringComparison>(RecordStringComparison).Invoke);
+            yield return ("Value", Adapters.For<StringComparison>(RecordStringComparison));
         }
 
         private bool RecordStringComparison(StringComparison value)
@@ -350,7 +350,7 @@ public class For_Func_Single
 
         protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
         {
-            yield return ("Value", Adapters.For<int>(RecordInt).Invoke);
+            yield return ("Value", Adapters.For<int>(RecordInt));
         }
 
         private bool RecordInt(int value)
@@ -369,7 +369,7 @@ public class For_Func_Single
 
         protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
         {
-            yield return ("Value", Adapters.For<IReadOnlyList<int>>(RecordIntArray).Invoke);
+            yield return ("Value", Adapters.For<IReadOnlyList<int>>(RecordIntArray));
         }
 
         private bool RecordIntArray(IReadOnlyList<int> value)
@@ -388,7 +388,7 @@ public class For_Func_Single
 
         protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
         {
-            yield return ("Value", Adapters.For<string>(RecordString).Invoke);
+            yield return ("Value", Adapters.For<string>(RecordString));
         }
 
         private bool RecordString(string value)
@@ -407,7 +407,7 @@ public class For_Func_Single
 
         protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
         {
-            yield return ("Value", Adapters.For<int>(RecordInt).Invoke);
+            yield return ("Value", Adapters.For<int>(RecordInt));
         }
 
         private bool RecordInt(int value)

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/For_Generic.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/For_Generic.cs
@@ -1,0 +1,46 @@
+﻿namespace SharpAttributeParser.Tests.ASemanticArgumentRecorderCases.AdapterCases;
+
+using Microsoft.CodeAnalysis;
+
+using Moq;
+
+using SharpAttributeParser;
+
+using System.Collections.Generic;
+
+using Xunit;
+
+public class For_Generic
+{
+    private static bool TryRecordGenericArgument(ASemanticArgumentRecorder recorder, string parameterName, ITypeSymbol value) => recorder.TryRecordGenericArgument(parameterName, value);
+
+    [Fact]
+    public void True_RecordedPopulated()
+    {
+        Recorder recorder = new();
+
+        var parameterName = "Value";
+        Mock<ITypeSymbol> symbolMock = new();
+
+        var actual = TryRecordGenericArgument(recorder, parameterName, symbolMock.Object);
+
+        Assert.True(actual);
+
+        Assert.Equal(symbolMock.Object, recorder.Value);
+    }
+
+    private sealed class Recorder : ASemanticArgumentRecorder
+    {
+        public ITypeSymbol? Value { get; private set; }
+
+        protected override IEnumerable<(string, DSemanticGenericRecorder)> AddGenericRecorders()
+        {
+            yield return ("Value", Adapters.For(RecordValue));
+        }
+
+        private void RecordValue(ITypeSymbol value)
+        {
+            Value = value;
+        }
+    }
+}

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AddArrayRecorders.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AddArrayRecorders.cs
@@ -63,12 +63,12 @@ public class AddArrayRecorders
 
     private sealed class NullGenericRecorder : ASemanticArgumentRecorder
     {
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders() => null!;
+        protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders() => null!;
     }
 
     private sealed class NullNameRecorder : ASemanticArgumentRecorder
     {
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
             yield return (null!, RecordValue);
         }
@@ -78,7 +78,7 @@ public class AddArrayRecorders
 
     private sealed class NullDelegateRecorder : ASemanticArgumentRecorder
     {
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("A", null!);
         }
@@ -86,7 +86,7 @@ public class AddArrayRecorders
 
     private sealed class DuplicateGenericRecorder : ASemanticArgumentRecorder
     {
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("A", RecordValue);
             yield return ("A", RecordValue);

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AddGenericRecorders.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AddGenericRecorders.cs
@@ -65,12 +65,12 @@ public class AddGenericRecorders
 
     private sealed class NullGenericRecorder : ASemanticArgumentRecorder
     {
-        protected override IEnumerable<(string, DGenericRecorder)> AddGenericRecorders() => null!;
+        protected override IEnumerable<(string, DSemanticGenericRecorder)> AddGenericRecorders() => null!;
     }
 
     private sealed class NullNameRecorder : ASemanticArgumentRecorder
     {
-        protected override IEnumerable<(string, DGenericRecorder)> AddGenericRecorders()
+        protected override IEnumerable<(string, DSemanticGenericRecorder)> AddGenericRecorders()
         {
             yield return (null!, RecordValue);
         }
@@ -80,7 +80,7 @@ public class AddGenericRecorders
 
     private sealed class NullDelegateRecorder : ASemanticArgumentRecorder
     {
-        protected override IEnumerable<(string, DGenericRecorder)> AddGenericRecorders()
+        protected override IEnumerable<(string, DSemanticGenericRecorder)> AddGenericRecorders()
         {
             yield return ("A", null!);
         }
@@ -88,7 +88,7 @@ public class AddGenericRecorders
 
     private sealed class DuplicateGenericRecorder : ASemanticArgumentRecorder
     {
-        protected override IEnumerable<(string, DGenericRecorder)> AddGenericRecorders()
+        protected override IEnumerable<(string, DSemanticGenericRecorder)> AddGenericRecorders()
         {
             yield return ("A", RecordValue);
             yield return ("A", RecordValue);

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AddSingleRecorders.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AddSingleRecorders.cs
@@ -63,12 +63,12 @@ public class AddSingleRecorders
 
     private sealed class NullGenericRecorder : ASemanticArgumentRecorder
     {
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders() => null!;
+        protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders() => null!;
     }
 
     private sealed class NullNameRecorder : ASemanticArgumentRecorder
     {
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+        protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
         {
             yield return (null!, RecordValue);
         }
@@ -78,7 +78,7 @@ public class AddSingleRecorders
 
     private sealed class NullDelegateRecorder : ASemanticArgumentRecorder
     {
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+        protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
         {
             yield return ("A", null!);
         }
@@ -86,7 +86,7 @@ public class AddSingleRecorders
 
     private sealed class DuplicateGenericRecorder : ASemanticArgumentRecorder
     {
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+        protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
         {
             yield return ("A", RecordValue);
             yield return ("A", RecordValue);

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/SemanticArgumentRecorder.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/SemanticArgumentRecorder.cs
@@ -20,17 +20,17 @@ internal sealed class SemanticArgumentRecorder : ASemanticArgumentRecorder
         Comparer = comparer;
     }
 
-    protected override IEnumerable<(string, DGenericRecorder)> AddGenericRecorders()
+    protected override IEnumerable<(string, DSemanticGenericRecorder)> AddGenericRecorders()
     {
         yield return ("TGeneric", RecordTGeneric);
     }
 
-    protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+    protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
     {
         yield return ("Value", RecordValue);
     }
 
-    protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+    protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
     {
         yield return ("Values", RecordValues);
     }

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullableCollection_Action.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullableCollection_Action.cs
@@ -321,7 +321,7 @@ public class ForNullableCollection_Action
 
         protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullableCollection<StringComparison>(RecordStringComparisonArray).Invoke);
+            yield return ("Value", Adapters.ForNullableCollection<StringComparison>(RecordStringComparisonArray));
         }
 
         private void RecordStringComparisonArray(IReadOnlyList<StringComparison>? value, Location collectionLocation, IReadOnlyList<Location> elementLocations)
@@ -338,7 +338,7 @@ public class ForNullableCollection_Action
 
         protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullableCollection<int>(RecordIntArray).Invoke);
+            yield return ("Value", Adapters.ForNullableCollection<int>(RecordIntArray));
         }
 
         private void RecordIntArray(IReadOnlyList<int>? value, Location collectionLocation, IReadOnlyList<Location> elementLocations)
@@ -355,7 +355,7 @@ public class ForNullableCollection_Action
 
         protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullableCollection<string>(RecordStringArray).Invoke);
+            yield return ("Value", Adapters.ForNullableCollection<string>(RecordStringArray));
         }
 
         private void RecordStringArray(IReadOnlyList<string>? value, Location collectionLocation, IReadOnlyList<Location> elementLocations)

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullableCollection_Action.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullableCollection_Action.cs
@@ -319,7 +319,7 @@ public class ForNullableCollection_Action
         public IReadOnlyList<StringComparison>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullableCollection<StringComparison>(RecordStringComparisonArray).Invoke);
         }
@@ -336,7 +336,7 @@ public class ForNullableCollection_Action
         public IReadOnlyList<int>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullableCollection<int>(RecordIntArray).Invoke);
         }
@@ -353,7 +353,7 @@ public class ForNullableCollection_Action
         public IReadOnlyList<string>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullableCollection<string>(RecordStringArray).Invoke);
         }

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullableCollection_Func.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullableCollection_Func.cs
@@ -334,7 +334,7 @@ public class ForNullableCollection_Func
         public IReadOnlyList<StringComparison>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullableCollection<StringComparison>(RecordStringComparisonArray).Invoke);
         }
@@ -353,7 +353,7 @@ public class ForNullableCollection_Func
         public IReadOnlyList<int>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullableCollection<int>(RecordIntArray).Invoke);
         }
@@ -372,7 +372,7 @@ public class ForNullableCollection_Func
         public IReadOnlyList<string>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullableCollection<string>(RecordStringArray).Invoke);
         }
@@ -391,7 +391,7 @@ public class ForNullableCollection_Func
         public IReadOnlyList<int>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullableCollection<int>(RecordIntArray).Invoke);
         }

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullableCollection_Func.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullableCollection_Func.cs
@@ -336,7 +336,7 @@ public class ForNullableCollection_Func
 
         protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullableCollection<StringComparison>(RecordStringComparisonArray).Invoke);
+            yield return ("Value", Adapters.ForNullableCollection<StringComparison>(RecordStringComparisonArray));
         }
 
         private bool RecordStringComparisonArray(IReadOnlyList<StringComparison>? value, Location collectionLocation, IReadOnlyList<Location> elementLocations)
@@ -355,7 +355,7 @@ public class ForNullableCollection_Func
 
         protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullableCollection<int>(RecordIntArray).Invoke);
+            yield return ("Value", Adapters.ForNullableCollection<int>(RecordIntArray));
         }
 
         private bool RecordIntArray(IReadOnlyList<int>? value, Location collectionLocation, IReadOnlyList<Location> elementLocations)
@@ -374,7 +374,7 @@ public class ForNullableCollection_Func
 
         protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullableCollection<string>(RecordStringArray).Invoke);
+            yield return ("Value", Adapters.ForNullableCollection<string>(RecordStringArray));
         }
 
         private bool RecordStringArray(IReadOnlyList<string>? value, Location collectionLocation, IReadOnlyList<Location> elementLocations)
@@ -393,7 +393,7 @@ public class ForNullableCollection_Func
 
         protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullableCollection<int>(RecordIntArray).Invoke);
+            yield return ("Value", Adapters.ForNullableCollection<int>(RecordIntArray));
         }
 
         private bool RecordIntArray(IReadOnlyList<int>? value, Location collectionLocation, IReadOnlyList<Location> elementLocations)

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullableElements_Action_Class.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullableElements_Action_Class.cs
@@ -78,7 +78,7 @@ public class ForNullableElements_Action_Class
 
         protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullableElements<string>(RecordStringArray).Invoke);
+            yield return ("Value", Adapters.ForNullableElements<string>(RecordStringArray));
         }
 
         private void RecordStringArray(IReadOnlyList<string?> value, Location collectionLocation, IReadOnlyList<Location> elementLocations)

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullableElements_Action_Class.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullableElements_Action_Class.cs
@@ -76,7 +76,7 @@ public class ForNullableElements_Action_Class
         public IReadOnlyList<string?>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullableElements<string>(RecordStringArray).Invoke);
         }

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullableElements_Action_Struct.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullableElements_Action_Struct.cs
@@ -256,7 +256,7 @@ public class ForNullableElements_Action_Struct
         public IReadOnlyList<StringComparison?>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullableElements<StringComparison>(RecordStringComparisonArray).Invoke);
         }
@@ -273,7 +273,7 @@ public class ForNullableElements_Action_Struct
         public IReadOnlyList<int?>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullableElements<int>(RecordIntArray).Invoke);
         }

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullableElements_Action_Struct.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullableElements_Action_Struct.cs
@@ -258,7 +258,7 @@ public class ForNullableElements_Action_Struct
 
         protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullableElements<StringComparison>(RecordStringComparisonArray).Invoke);
+            yield return ("Value", Adapters.ForNullableElements<StringComparison>(RecordStringComparisonArray));
         }
 
         private void RecordStringComparisonArray(IReadOnlyList<StringComparison?> value, Location collectionLocation, IReadOnlyList<Location> elementLocations)
@@ -275,7 +275,7 @@ public class ForNullableElements_Action_Struct
 
         protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullableElements<int>(RecordIntArray).Invoke);
+            yield return ("Value", Adapters.ForNullableElements<int>(RecordIntArray));
         }
 
         private void RecordIntArray(IReadOnlyList<int?> value, Location collectionLocation, IReadOnlyList<Location> elementLocations)

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullableElements_Func_Class.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullableElements_Func_Class.cs
@@ -91,7 +91,7 @@ public class ForNullableElements_Func_Class
         public IReadOnlyList<string?>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullableElements<string>(RecordStringArray).Invoke);
         }
@@ -110,7 +110,7 @@ public class ForNullableElements_Func_Class
         public IReadOnlyList<string?>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullableElements<string>(RecordStringArray).Invoke);
         }

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullableElements_Func_Class.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullableElements_Func_Class.cs
@@ -93,7 +93,7 @@ public class ForNullableElements_Func_Class
 
         protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullableElements<string>(RecordStringArray).Invoke);
+            yield return ("Value", Adapters.ForNullableElements<string>(RecordStringArray));
         }
 
         private bool RecordStringArray(IReadOnlyList<string?> value, Location collectionLocation, IReadOnlyList<Location> elementLocations)
@@ -112,7 +112,7 @@ public class ForNullableElements_Func_Class
 
         protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullableElements<string>(RecordStringArray).Invoke);
+            yield return ("Value", Adapters.ForNullableElements<string>(RecordStringArray));
         }
 
         private bool RecordStringArray(IReadOnlyList<string?> value, Location collectionLocation, IReadOnlyList<Location> elementLocations)

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullableElements_Func_Struct.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullableElements_Func_Struct.cs
@@ -273,7 +273,7 @@ public class ForNullableElements_Func_Struct
 
         protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullableElements<StringComparison>(RecordStringComparisonArray).Invoke);
+            yield return ("Value", Adapters.ForNullableElements<StringComparison>(RecordStringComparisonArray));
         }
 
         private bool RecordStringComparisonArray(IReadOnlyList<StringComparison?> value, Location collectionLocation, IReadOnlyList<Location> elementLocations)
@@ -292,7 +292,7 @@ public class ForNullableElements_Func_Struct
 
         protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullableElements<int>(RecordIntArray).Invoke);
+            yield return ("Value", Adapters.ForNullableElements<int>(RecordIntArray));
         }
 
         private bool RecordIntArray(IReadOnlyList<int?> value, Location collectionLocation, IReadOnlyList<Location> elementLocations)
@@ -311,7 +311,7 @@ public class ForNullableElements_Func_Struct
 
         protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullableElements<int>(RecordIntArray).Invoke);
+            yield return ("Value", Adapters.ForNullableElements<int>(RecordIntArray));
         }
 
         private bool RecordIntArray(IReadOnlyList<int?> value, Location collectionLocation, IReadOnlyList<Location> elementLocations)

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullableElements_Func_Struct.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullableElements_Func_Struct.cs
@@ -271,7 +271,7 @@ public class ForNullableElements_Func_Struct
         public IReadOnlyList<StringComparison?>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullableElements<StringComparison>(RecordStringComparisonArray).Invoke);
         }
@@ -290,7 +290,7 @@ public class ForNullableElements_Func_Struct
         public IReadOnlyList<int?>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullableElements<int>(RecordIntArray).Invoke);
         }
@@ -309,7 +309,7 @@ public class ForNullableElements_Func_Struct
         public IReadOnlyList<int?>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullableElements<int>(RecordIntArray).Invoke);
         }

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Action_Array_Class.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Action_Array_Class.cs
@@ -77,7 +77,7 @@ public class ForNullable_Action_Array_Class
         public IReadOnlyList<string?>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullable<string>(RecordStringArray).Invoke);
         }

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Action_Array_Class.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Action_Array_Class.cs
@@ -79,7 +79,7 @@ public class ForNullable_Action_Array_Class
 
         protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullable<string>(RecordStringArray).Invoke);
+            yield return ("Value", Adapters.ForNullable<string>(RecordStringArray));
         }
 
         private void RecordStringArray(IReadOnlyList<string?>? value, Location collectionLocation, IReadOnlyList<Location> elementLocations)

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Action_Array_Struct.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Action_Array_Struct.cs
@@ -260,7 +260,7 @@ public class ForNullable_Action_Array_Struct
 
         protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullable<StringComparison>(RecordStringComparisonArray).Invoke);
+            yield return ("Value", Adapters.ForNullable<StringComparison>(RecordStringComparisonArray));
         }
 
         private void RecordStringComparisonArray(IReadOnlyList<StringComparison?>? value, Location collectionLocation, IReadOnlyList<Location> elementLocations)
@@ -277,7 +277,7 @@ public class ForNullable_Action_Array_Struct
 
         protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullable<int>(RecordIntArray).Invoke);
+            yield return ("Value", Adapters.ForNullable<int>(RecordIntArray));
         }
 
         private void RecordIntArray(IReadOnlyList<int?>? value, Location collectionLocation, IReadOnlyList<Location> elementLocations)

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Action_Array_Struct.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Action_Array_Struct.cs
@@ -258,7 +258,7 @@ public class ForNullable_Action_Array_Struct
         public IReadOnlyList<StringComparison?>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullable<StringComparison>(RecordStringComparisonArray).Invoke);
         }
@@ -275,7 +275,7 @@ public class ForNullable_Action_Array_Struct
         public IReadOnlyList<int?>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullable<int>(RecordIntArray).Invoke);
         }

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Action_Single_Class.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Action_Single_Class.cs
@@ -109,7 +109,7 @@ public class ForNullable_Action_Single_Class
 
         protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders()
         {
-            yield return ("Value", Adapters.ForNullable<IReadOnlyList<int>>(RecordIntArray).Invoke);
+            yield return ("Value", Adapters.ForNullable<IReadOnlyList<int>>(RecordIntArray));
         }
 
         private void RecordIntArray(IReadOnlyList<int>? value, Location location)
@@ -126,7 +126,7 @@ public class ForNullable_Action_Single_Class
 
         protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders()
         {
-            yield return ("Value", Adapters.ForNullable<string>(RecordString).Invoke);
+            yield return ("Value", Adapters.ForNullable<string>(RecordString));
         }
 
         private void RecordString(string? value, Location location)

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Action_Single_Class.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Action_Single_Class.cs
@@ -107,7 +107,7 @@ public class ForNullable_Action_Single_Class
         public IReadOnlyList<int>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+        protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders()
         {
             yield return ("Value", Adapters.ForNullable<IReadOnlyList<int>>(RecordIntArray).Invoke);
         }
@@ -124,7 +124,7 @@ public class ForNullable_Action_Single_Class
         public string? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+        protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders()
         {
             yield return ("Value", Adapters.ForNullable<string>(RecordString).Invoke);
         }

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Action_Single_Struct.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Action_Single_Struct.cs
@@ -230,7 +230,7 @@ public class ForNullable_Action_Single_Struct
 
         protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders()
         {
-            yield return ("Value", Adapters.ForNullable<StringComparison>(RecordStringComparison).Invoke);
+            yield return ("Value", Adapters.ForNullable<StringComparison>(RecordStringComparison));
         }
 
         private void RecordStringComparison(StringComparison? value, Location location)
@@ -247,7 +247,7 @@ public class ForNullable_Action_Single_Struct
 
         protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders()
         {
-            yield return ("Value", Adapters.ForNullable<int>(RecordInt).Invoke);
+            yield return ("Value", Adapters.ForNullable<int>(RecordInt));
         }
 
         private void RecordInt(int? value, Location location)

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Action_Single_Struct.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Action_Single_Struct.cs
@@ -228,7 +228,7 @@ public class ForNullable_Action_Single_Struct
         public StringComparison? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+        protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders()
         {
             yield return ("Value", Adapters.ForNullable<StringComparison>(RecordStringComparison).Invoke);
         }
@@ -245,7 +245,7 @@ public class ForNullable_Action_Single_Struct
         public int? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+        protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders()
         {
             yield return ("Value", Adapters.ForNullable<int>(RecordInt).Invoke);
         }

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Func_Array_Class.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Func_Array_Class.cs
@@ -92,7 +92,7 @@ public class ForNullable_Func_Array_Class
         public IReadOnlyList<string?>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullable<string>(RecordStringArray).Invoke);
         }
@@ -111,7 +111,7 @@ public class ForNullable_Func_Array_Class
         public IReadOnlyList<string?>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullable<string>(RecordStringArray).Invoke);
         }

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Func_Array_Class.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Func_Array_Class.cs
@@ -94,7 +94,7 @@ public class ForNullable_Func_Array_Class
 
         protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullable<string>(RecordStringArray).Invoke);
+            yield return ("Value", Adapters.ForNullable<string>(RecordStringArray));
         }
 
         private bool RecordStringArray(IReadOnlyList<string?>? value, Location collectionLocation, IReadOnlyList<Location> elementLocations)
@@ -113,7 +113,7 @@ public class ForNullable_Func_Array_Class
 
         protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullable<string>(RecordStringArray).Invoke);
+            yield return ("Value", Adapters.ForNullable<string>(RecordStringArray));
         }
 
         private bool RecordStringArray(IReadOnlyList<string?>? value, Location collectionLocation, IReadOnlyList<Location> elementLocations)

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Func_Array_Struct.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Func_Array_Struct.cs
@@ -275,7 +275,7 @@ public class ForNullable_Func_Array_Struct
 
         protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullable<StringComparison>(RecordStringComparisonArray).Invoke);
+            yield return ("Value", Adapters.ForNullable<StringComparison>(RecordStringComparisonArray));
         }
 
         private bool RecordStringComparisonArray(IReadOnlyList<StringComparison?>? value, Location collectionLocation, IReadOnlyList<Location> elementLocations)
@@ -294,7 +294,7 @@ public class ForNullable_Func_Array_Struct
 
         protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullable<int>(RecordIntArray).Invoke);
+            yield return ("Value", Adapters.ForNullable<int>(RecordIntArray));
         }
 
         private bool RecordIntArray(IReadOnlyList<int?>? value, Location collectionLocation, IReadOnlyList<Location> elementLocations)
@@ -313,7 +313,7 @@ public class ForNullable_Func_Array_Struct
 
         protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.ForNullable<int>(RecordIntArray).Invoke);
+            yield return ("Value", Adapters.ForNullable<int>(RecordIntArray));
         }
 
         private bool RecordIntArray(IReadOnlyList<int?>? value, Location collectionLocation, IReadOnlyList<Location> elementLocations)

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Func_Array_Struct.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Func_Array_Struct.cs
@@ -273,7 +273,7 @@ public class ForNullable_Func_Array_Struct
         public IReadOnlyList<StringComparison?>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullable<StringComparison>(RecordStringComparisonArray).Invoke);
         }
@@ -292,7 +292,7 @@ public class ForNullable_Func_Array_Struct
         public IReadOnlyList<int?>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullable<int>(RecordIntArray).Invoke);
         }
@@ -311,7 +311,7 @@ public class ForNullable_Func_Array_Struct
         public IReadOnlyList<int?>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.ForNullable<int>(RecordIntArray).Invoke);
         }

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Func_Single_Class.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Func_Single_Class.cs
@@ -125,7 +125,7 @@ public class ForNullable_Func_Single_Class
 
         protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders()
         {
-            yield return ("Value", Adapters.ForNullable<IReadOnlyList<int>>(RecordIntArray).Invoke);
+            yield return ("Value", Adapters.ForNullable<IReadOnlyList<int>>(RecordIntArray));
         }
 
         private bool RecordIntArray(IReadOnlyList<int>? value, Location location)
@@ -144,7 +144,7 @@ public class ForNullable_Func_Single_Class
 
         protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders()
         {
-            yield return ("Value", Adapters.ForNullable<string>(RecordString).Invoke);
+            yield return ("Value", Adapters.ForNullable<string>(RecordString));
         }
 
         private bool RecordString(string? value, Location location)
@@ -163,7 +163,7 @@ public class ForNullable_Func_Single_Class
 
         protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders()
         {
-            yield return ("Value", Adapters.ForNullable<string>(RecordString).Invoke);
+            yield return ("Value", Adapters.ForNullable<string>(RecordString));
         }
 
         private bool RecordString(string? value, Location location)

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Func_Single_Class.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Func_Single_Class.cs
@@ -123,7 +123,7 @@ public class ForNullable_Func_Single_Class
         public IReadOnlyList<int>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+        protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders()
         {
             yield return ("Value", Adapters.ForNullable<IReadOnlyList<int>>(RecordIntArray).Invoke);
         }
@@ -142,7 +142,7 @@ public class ForNullable_Func_Single_Class
         public string? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+        protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders()
         {
             yield return ("Value", Adapters.ForNullable<string>(RecordString).Invoke);
         }
@@ -161,7 +161,7 @@ public class ForNullable_Func_Single_Class
         public string? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+        protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders()
         {
             yield return ("Value", Adapters.ForNullable<string>(RecordString).Invoke);
         }

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Func_Single_Struct.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Func_Single_Struct.cs
@@ -243,7 +243,7 @@ public class ForNullable_Func_Single_Struct
         public StringComparison? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+        protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders()
         {
             yield return ("Value", Adapters.ForNullable<StringComparison>(RecordStringComparison).Invoke);
         }
@@ -262,7 +262,7 @@ public class ForNullable_Func_Single_Struct
         public int? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+        protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders()
         {
             yield return ("Value", Adapters.ForNullable<int>(RecordInt).Invoke);
         }
@@ -281,7 +281,7 @@ public class ForNullable_Func_Single_Struct
         public int? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+        protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders()
         {
             yield return ("Value", Adapters.ForNullable<int>(RecordInt).Invoke);
         }

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Func_Single_Struct.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Func_Single_Struct.cs
@@ -245,7 +245,7 @@ public class ForNullable_Func_Single_Struct
 
         protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders()
         {
-            yield return ("Value", Adapters.ForNullable<StringComparison>(RecordStringComparison).Invoke);
+            yield return ("Value", Adapters.ForNullable<StringComparison>(RecordStringComparison));
         }
 
         private bool RecordStringComparison(StringComparison? value, Location location)
@@ -264,7 +264,7 @@ public class ForNullable_Func_Single_Struct
 
         protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders()
         {
-            yield return ("Value", Adapters.ForNullable<int>(RecordInt).Invoke);
+            yield return ("Value", Adapters.ForNullable<int>(RecordInt));
         }
 
         private bool RecordInt(int? value, Location location)
@@ -283,7 +283,7 @@ public class ForNullable_Func_Single_Struct
 
         protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders()
         {
-            yield return ("Value", Adapters.ForNullable<int>(RecordInt).Invoke);
+            yield return ("Value", Adapters.ForNullable<int>(RecordInt));
         }
 
         private bool RecordInt(int? value, Location location)

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/For_Action_Array.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/For_Action_Array.cs
@@ -316,7 +316,7 @@ public class For_Action_Array
         public IReadOnlyList<StringComparison>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.For<StringComparison>(RecordStringComparisonArray).Invoke);
         }
@@ -333,7 +333,7 @@ public class For_Action_Array
         public IReadOnlyList<int>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.For<int>(RecordIntArray).Invoke);
         }
@@ -350,7 +350,7 @@ public class For_Action_Array
         public IReadOnlyList<string>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.For<string>(RecordStringArray).Invoke);
         }

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/For_Action_Array.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/For_Action_Array.cs
@@ -318,7 +318,7 @@ public class For_Action_Array
 
         protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.For<StringComparison>(RecordStringComparisonArray).Invoke);
+            yield return ("Value", Adapters.For<StringComparison>(RecordStringComparisonArray));
         }
 
         private void RecordStringComparisonArray(IReadOnlyList<StringComparison> value, Location collectionLocation, IReadOnlyList<Location> elementLocations)
@@ -335,7 +335,7 @@ public class For_Action_Array
 
         protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.For<int>(RecordIntArray).Invoke);
+            yield return ("Value", Adapters.For<int>(RecordIntArray));
         }
 
         private void RecordIntArray(IReadOnlyList<int> value, Location collectionLocation, IReadOnlyList<Location> elementLocations)
@@ -352,7 +352,7 @@ public class For_Action_Array
 
         protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.For<string>(RecordStringArray).Invoke);
+            yield return ("Value", Adapters.For<string>(RecordStringArray));
         }
 
         private void RecordStringArray(IReadOnlyList<string> value, Location collectionLocation, IReadOnlyList<Location> elementLocations)

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/For_Action_Single.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/For_Action_Single.cs
@@ -316,7 +316,7 @@ public class For_Action_Single
         public StringComparison? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+        protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders()
         {
             yield return ("Value", Adapters.For<StringComparison>(RecordStringComparison).Invoke);
         }
@@ -333,7 +333,7 @@ public class For_Action_Single
         public int? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+        protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders()
         {
             yield return ("Value", Adapters.For<int>(RecordInt).Invoke);
         }
@@ -350,7 +350,7 @@ public class For_Action_Single
         public IReadOnlyList<int>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+        protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders()
         {
             yield return ("Value", Adapters.For<IReadOnlyList<int>>(RecordIntArray).Invoke);
         }
@@ -367,7 +367,7 @@ public class For_Action_Single
         public string? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+        protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders()
         {
             yield return ("Value", Adapters.For<string>(RecordString).Invoke);
         }

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/For_Action_Single.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/For_Action_Single.cs
@@ -318,7 +318,7 @@ public class For_Action_Single
 
         protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders()
         {
-            yield return ("Value", Adapters.For<StringComparison>(RecordStringComparison).Invoke);
+            yield return ("Value", Adapters.For<StringComparison>(RecordStringComparison));
         }
 
         private void RecordStringComparison(StringComparison value, Location location)
@@ -335,7 +335,7 @@ public class For_Action_Single
 
         protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders()
         {
-            yield return ("Value", Adapters.For<int>(RecordInt).Invoke);
+            yield return ("Value", Adapters.For<int>(RecordInt));
         }
 
         private void RecordInt(int value, Location location)
@@ -352,7 +352,7 @@ public class For_Action_Single
 
         protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders()
         {
-            yield return ("Value", Adapters.For<IReadOnlyList<int>>(RecordIntArray).Invoke);
+            yield return ("Value", Adapters.For<IReadOnlyList<int>>(RecordIntArray));
         }
 
         private void RecordIntArray(IReadOnlyList<int> value, Location location)
@@ -369,7 +369,7 @@ public class For_Action_Single
 
         protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders()
         {
-            yield return ("Value", Adapters.For<string>(RecordString).Invoke);
+            yield return ("Value", Adapters.For<string>(RecordString));
         }
 
         private void RecordString(string value, Location location)

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/For_Func_Array.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/For_Func_Array.cs
@@ -333,7 +333,7 @@ public class For_Func_Array
 
         protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.For<StringComparison>(RecordStringComparisonArray).Invoke);
+            yield return ("Value", Adapters.For<StringComparison>(RecordStringComparisonArray));
         }
 
         private bool RecordStringComparisonArray(IReadOnlyList<StringComparison> value, Location collectionLocation, IReadOnlyList<Location> elementLocations)
@@ -352,7 +352,7 @@ public class For_Func_Array
 
         protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.For<int>(RecordIntArray).Invoke);
+            yield return ("Value", Adapters.For<int>(RecordIntArray));
         }
 
         private bool RecordIntArray(IReadOnlyList<int> value, Location collectionLocation, IReadOnlyList<Location> elementLocations)
@@ -371,7 +371,7 @@ public class For_Func_Array
 
         protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.For<string>(RecordStringArray).Invoke);
+            yield return ("Value", Adapters.For<string>(RecordStringArray));
         }
 
         private bool RecordStringArray(IReadOnlyList<string> value, Location collectionLocation, IReadOnlyList<Location> elementLocations)
@@ -390,7 +390,7 @@ public class For_Func_Array
 
         protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
-            yield return ("Value", Adapters.For<int>(RecordInt).Invoke);
+            yield return ("Value", Adapters.For<int>(RecordInt));
         }
 
         private bool RecordInt(IReadOnlyList<int> value, Location collectionLocation, IReadOnlyList<Location> elementLocations)

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/For_Func_Array.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/For_Func_Array.cs
@@ -331,7 +331,7 @@ public class For_Func_Array
         public IReadOnlyList<StringComparison>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.For<StringComparison>(RecordStringComparisonArray).Invoke);
         }
@@ -350,7 +350,7 @@ public class For_Func_Array
         public IReadOnlyList<int>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.For<int>(RecordIntArray).Invoke);
         }
@@ -369,7 +369,7 @@ public class For_Func_Array
         public IReadOnlyList<string>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.For<string>(RecordStringArray).Invoke);
         }
@@ -388,7 +388,7 @@ public class For_Func_Array
         public IReadOnlyList<int>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("Value", Adapters.For<int>(RecordInt).Invoke);
         }

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/For_Func_Single.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/For_Func_Single.cs
@@ -333,7 +333,7 @@ public class For_Func_Single
 
         protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders()
         {
-            yield return ("Value", Adapters.For<StringComparison>(RecordStringComparison).Invoke);
+            yield return ("Value", Adapters.For<StringComparison>(RecordStringComparison));
         }
 
         private bool RecordStringComparison(StringComparison value, Location location)
@@ -352,7 +352,7 @@ public class For_Func_Single
 
         protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders()
         {
-            yield return ("Value", Adapters.For<int>(RecordInt).Invoke);
+            yield return ("Value", Adapters.For<int>(RecordInt));
         }
 
         private bool RecordInt(int value, Location location)
@@ -371,7 +371,7 @@ public class For_Func_Single
 
         protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders()
         {
-            yield return ("Value", Adapters.For<IReadOnlyList<int>>(RecordIntArray).Invoke);
+            yield return ("Value", Adapters.For<IReadOnlyList<int>>(RecordIntArray));
         }
 
         private bool RecordIntArray(IReadOnlyList<int> value, Location location)
@@ -390,7 +390,7 @@ public class For_Func_Single
 
         protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders()
         {
-            yield return ("Value", Adapters.For<string>(RecordString).Invoke);
+            yield return ("Value", Adapters.For<string>(RecordString));
         }
 
         private bool RecordString(string value, Location location)
@@ -409,7 +409,7 @@ public class For_Func_Single
 
         protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders()
         {
-            yield return ("Value", Adapters.For<int>(RecordInt).Invoke);
+            yield return ("Value", Adapters.For<int>(RecordInt));
         }
 
         private bool RecordInt(int value, Location location)

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/For_Func_Single.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/For_Func_Single.cs
@@ -331,7 +331,7 @@ public class For_Func_Single
         public StringComparison? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+        protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders()
         {
             yield return ("Value", Adapters.For<StringComparison>(RecordStringComparison).Invoke);
         }
@@ -350,7 +350,7 @@ public class For_Func_Single
         public int? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+        protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders()
         {
             yield return ("Value", Adapters.For<int>(RecordInt).Invoke);
         }
@@ -369,7 +369,7 @@ public class For_Func_Single
         public IReadOnlyList<int>? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+        protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders()
         {
             yield return ("Value", Adapters.For<IReadOnlyList<int>>(RecordIntArray).Invoke);
         }
@@ -388,7 +388,7 @@ public class For_Func_Single
         public string? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+        protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders()
         {
             yield return ("Value", Adapters.For<string>(RecordString).Invoke);
         }
@@ -407,7 +407,7 @@ public class For_Func_Single
         public int? Value { get; private set; }
         public bool ValueRecorded { get; private set; }
 
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+        protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders()
         {
             yield return ("Value", Adapters.For<int>(RecordInt).Invoke);
         }

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/For_Generic.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/For_Generic.cs
@@ -1,0 +1,46 @@
+﻿namespace SharpAttributeParser.Tests.ASyntacticArgumentRecorderCases.AdapterCases;
+
+using Microsoft.CodeAnalysis;
+
+using Moq;
+
+using SharpAttributeParser;
+
+using System.Collections.Generic;
+
+using Xunit;
+
+public class For_Generic
+{
+    private static bool TryRecordGenericArgument(ASyntacticArgumentRecorder recorder, string parameterName, ITypeSymbol value) => recorder.TryRecordGenericArgument(parameterName, value, Location.None);
+
+    [Fact]
+    public void True_RecordedPopulated()
+    {
+        Recorder recorder = new();
+
+        var parameterName = "Value";
+        Mock<ITypeSymbol> symbolMock = new();
+
+        var actual = TryRecordGenericArgument(recorder, parameterName, symbolMock.Object);
+
+        Assert.True(actual);
+
+        Assert.Equal(symbolMock.Object, recorder.Value);
+    }
+
+    private sealed class Recorder : ASyntacticArgumentRecorder
+    {
+        public ITypeSymbol? Value { get; private set; }
+
+        protected override IEnumerable<(string, DSyntacticGenericRecorder)> AddGenericRecorders()
+        {
+            yield return ("Value", Adapters.For(RecordValue));
+        }
+
+        private void RecordValue(ITypeSymbol value, Location location)
+        {
+            Value = value;
+        }
+    }
+}

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AddArrayRecorders.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AddArrayRecorders.cs
@@ -69,12 +69,12 @@ public class AddArrayRecorders
 
     private sealed class NullGenericRecorder : ASyntacticArgumentRecorder
     {
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders() => null!;
+        protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders() => null!;
     }
 
     private sealed class NullNameRecorder : ASyntacticArgumentRecorder
     {
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
             yield return (null!, RecordValue);
         }
@@ -84,7 +84,7 @@ public class AddArrayRecorders
 
     private sealed class NullDelegateRecorder : ASyntacticArgumentRecorder
     {
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("A", null!);
         }
@@ -92,7 +92,7 @@ public class AddArrayRecorders
 
     private sealed class DuplicateGenericRecorder : ASyntacticArgumentRecorder
     {
-        protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+        protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
         {
             yield return ("A", RecordValue);
             yield return ("A", RecordValue);

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AddGenericRecorders.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AddGenericRecorders.cs
@@ -69,12 +69,12 @@ public class AddGenericRecorders
 
     private sealed class NullGenericRecorder : ASyntacticArgumentRecorder
     {
-        protected override IEnumerable<(string, DGenericRecorder)> AddGenericRecorders() => null!;
+        protected override IEnumerable<(string, DSyntacticGenericRecorder)> AddGenericRecorders() => null!;
     }
 
     private sealed class NullNameRecorder : ASyntacticArgumentRecorder
     {
-        protected override IEnumerable<(string, DGenericRecorder)> AddGenericRecorders()
+        protected override IEnumerable<(string, DSyntacticGenericRecorder)> AddGenericRecorders()
         {
             yield return (null!, RecordValue);
         }
@@ -84,7 +84,7 @@ public class AddGenericRecorders
 
     private sealed class NullDelegateRecorder : ASyntacticArgumentRecorder
     {
-        protected override IEnumerable<(string, DGenericRecorder)> AddGenericRecorders()
+        protected override IEnumerable<(string, DSyntacticGenericRecorder)> AddGenericRecorders()
         {
             yield return ("A", null!);
         }
@@ -92,7 +92,7 @@ public class AddGenericRecorders
 
     private sealed class DuplicateGenericRecorder : ASyntacticArgumentRecorder
     {
-        protected override IEnumerable<(string, DGenericRecorder)> AddGenericRecorders()
+        protected override IEnumerable<(string, DSyntacticGenericRecorder)> AddGenericRecorders()
         {
             yield return ("A", RecordValue);
             yield return ("A", RecordValue);

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AddSingleRecorders.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AddSingleRecorders.cs
@@ -69,12 +69,12 @@ public class AddSingleRecorders
 
     private sealed class NullGenericRecorder : ASyntacticArgumentRecorder
     {
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders() => null!;
+        protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders() => null!;
     }
 
     private sealed class NullNameRecorder : ASyntacticArgumentRecorder
     {
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+        protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders()
         {
             yield return (null!, RecordValue);
         }
@@ -84,7 +84,7 @@ public class AddSingleRecorders
 
     private sealed class NullDelegateRecorder : ASyntacticArgumentRecorder
     {
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+        protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders()
         {
             yield return ("A", null!);
         }
@@ -92,7 +92,7 @@ public class AddSingleRecorders
 
     private sealed class DuplicateGenericRecorder : ASyntacticArgumentRecorder
     {
-        protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+        protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders()
         {
             yield return ("A", RecordValue);
             yield return ("A", RecordValue);

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/SyntacticArgumentRecorder.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/SyntacticArgumentRecorder.cs
@@ -22,17 +22,17 @@ internal sealed class SyntacticArgumentRecorder : ASyntacticArgumentRecorder
         Comparer = comparer;
     }
 
-    protected override IEnumerable<(string, DGenericRecorder)> AddGenericRecorders()
+    protected override IEnumerable<(string, DSyntacticGenericRecorder)> AddGenericRecorders()
     {
         yield return ("TGeneric", RecordTGeneric);
     }
 
-    protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+    protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders()
     {
         yield return ("Value", RecordValue);
     }
 
-    protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+    protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
     {
         yield return ("Values", RecordValues);
     }

--- a/src/SharpAttributeParser.Tests/ISemanticAttributeParserCases/SemanticArrayConstructorAttributeRecorder.cs
+++ b/src/SharpAttributeParser.Tests/ISemanticAttributeParserCases/SemanticArrayConstructorAttributeRecorder.cs
@@ -9,7 +9,7 @@ public sealed class SemanticArrayConstructorAttributeRecorder : ASemanticArgumen
     public IReadOnlyList<object?>? Value { get; private set; }
     public bool ValueRecorded { get; private set; }
 
-    protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+    protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
     {
         yield return ("Value", RecordValue);
     }

--- a/src/SharpAttributeParser.Tests/ISemanticAttributeParserCases/SemanticCombinedAttributeRecorder.cs
+++ b/src/SharpAttributeParser.Tests/ISemanticAttributeParserCases/SemanticCombinedAttributeRecorder.cs
@@ -24,19 +24,19 @@ public sealed class SemanticCombinedAttributeRecorder : ASemanticArgumentRecorde
     public IReadOnlyList<object?>? NamedValues { get; private set; }
     public bool NamedValuesRecorded { get; private set; }
 
-    protected override IEnumerable<(string, DGenericRecorder)> AddGenericRecorders()
+    protected override IEnumerable<(string, DSemanticGenericRecorder)> AddGenericRecorders()
     {
         yield return ("T1", RecordT1);
         yield return ("T2", RecordT2);
     }
 
-    protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+    protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
     {
         yield return ("Value", RecordValue);
         yield return ("NamedValue", RecordNamedValue);
     }
 
-    protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+    protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
     {
         yield return ("ArrayValues", RecordArrayValues);
         yield return ("ParamsValues", RecordParamsValues);

--- a/src/SharpAttributeParser.Tests/ISemanticAttributeParserCases/SemanticGenericAttributeRecorder.cs
+++ b/src/SharpAttributeParser.Tests/ISemanticAttributeParserCases/SemanticGenericAttributeRecorder.cs
@@ -8,7 +8,7 @@ public sealed class SemanticGenericAttributeRecorder : ASemanticArgumentRecorder
 {
     public ITypeSymbol? T { get; private set; }
 
-    protected override IEnumerable<(string, DGenericRecorder)> AddGenericRecorders()
+    protected override IEnumerable<(string, DSemanticGenericRecorder)> AddGenericRecorders()
     {
         yield return ("T", RecordT);
     }

--- a/src/SharpAttributeParser.Tests/ISemanticAttributeParserCases/SemanticNamedAttributeRecorder.cs
+++ b/src/SharpAttributeParser.Tests/ISemanticAttributeParserCases/SemanticNamedAttributeRecorder.cs
@@ -10,12 +10,12 @@ public sealed class SemanticNamedAttributeRecorder : ASemanticArgumentRecorder
     public IReadOnlyList<object?>? Values { get; private set; }
     public bool ValuesRecorded { get; private set; }
 
-    protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+    protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
     {
         yield return ("Value", RecordValue);
     }
 
-    protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+    protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
     {
         yield return ("Values", RecordValues);
     }

--- a/src/SharpAttributeParser.Tests/ISemanticAttributeParserCases/SemanticSingleConstructorAttributeRecorder.cs
+++ b/src/SharpAttributeParser.Tests/ISemanticAttributeParserCases/SemanticSingleConstructorAttributeRecorder.cs
@@ -7,7 +7,7 @@ public sealed class SemanticSingleConstructorAttributeRecorder : ASemanticArgume
     public object? Value { get; private set; }
     public bool ValueRecorded { get; private set; }
 
-    protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+    protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
     {
         yield return ("Value", RecordValue);
     }

--- a/src/SharpAttributeParser.Tests/ISyntacticAttributeParserCases/SyntacticArrayConstructorAttributeRecorder.cs
+++ b/src/SharpAttributeParser.Tests/ISyntacticAttributeParserCases/SyntacticArrayConstructorAttributeRecorder.cs
@@ -13,7 +13,7 @@ public sealed class SyntacticArrayConstructorAttributeRecorder : ASyntacticArgum
     public IReadOnlyList<Location>? ValueElementLocations { get; private set; }
     public bool ValueRecorded { get; private set; }
 
-    protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+    protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
     {
         yield return ("Value", RecordValue);
     }

--- a/src/SharpAttributeParser.Tests/ISyntacticAttributeParserCases/SyntacticCombinedAttributeRecorder.cs
+++ b/src/SharpAttributeParser.Tests/ISyntacticAttributeParserCases/SyntacticCombinedAttributeRecorder.cs
@@ -35,19 +35,19 @@ public sealed class SyntacticCombinedAttributeRecorder : ASyntacticArgumentRecor
     public IReadOnlyList<Location>? NamedValuesElementLocations { get; private set; }
     public bool NamedValuesRecorded { get; private set; }
 
-    protected override IEnumerable<(string, DGenericRecorder)> AddGenericRecorders()
+    protected override IEnumerable<(string, DSyntacticGenericRecorder)> AddGenericRecorders()
     {
         yield return ("T1", RecordT1);
         yield return ("T2", RecordT2);
     }
 
-    protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+    protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders()
     {
         yield return ("Value", RecordValue);
         yield return ("NamedValue", RecordNamedValue);
     }
 
-    protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+    protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
     {
         yield return ("ArrayValues", RecordArrayValues);
         yield return ("ParamsValues", RecordParamsValues);

--- a/src/SharpAttributeParser.Tests/ISyntacticAttributeParserCases/SyntacticGenericAttributeRecorder.cs
+++ b/src/SharpAttributeParser.Tests/ISyntacticAttributeParserCases/SyntacticGenericAttributeRecorder.cs
@@ -9,7 +9,7 @@ public sealed class SyntacticGenericAttributeRecorder : ASyntacticArgumentRecord
     public ITypeSymbol? T { get; private set; }
     public Location? TLocation { get; private set; }
 
-    protected override IEnumerable<(string, DGenericRecorder)> AddGenericRecorders()
+    protected override IEnumerable<(string, DSyntacticGenericRecorder)> AddGenericRecorders()
     {
         yield return ("T", RecordT);
     }

--- a/src/SharpAttributeParser.Tests/ISyntacticAttributeParserCases/SyntacticNamedAttributeRecorder.cs
+++ b/src/SharpAttributeParser.Tests/ISyntacticAttributeParserCases/SyntacticNamedAttributeRecorder.cs
@@ -15,12 +15,12 @@ public sealed class SyntacticNamedAttributeRecorder : ASyntacticArgumentRecorder
     public IReadOnlyList<Location>? ValuesElementLocations { get; private set; }
     public bool ValuesRecorded { get; private set; }
 
-    protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+    protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders()
     {
         yield return ("Value", RecordValue);
     }
 
-    protected override IEnumerable<(string, DArrayRecorder)> AddArrayRecorders()
+    protected override IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders()
     {
         yield return ("Values", RecordValues);
     }

--- a/src/SharpAttributeParser.Tests/ISyntacticAttributeParserCases/SyntacticSingleConstructorAttributeRecorder.cs
+++ b/src/SharpAttributeParser.Tests/ISyntacticAttributeParserCases/SyntacticSingleConstructorAttributeRecorder.cs
@@ -10,7 +10,7 @@ public sealed class SyntacticSingleConstructorAttributeRecorder : ASyntacticArgu
     public Location? ValueLocation { get; private set; }
     public bool ValueRecorded { get; private set; }
 
-    protected override IEnumerable<(string, DSingleRecorder)> AddSingleRecorders()
+    protected override IEnumerable<(string, DSyntacticSingleRecorder)> AddSingleRecorders()
     {
         yield return ("Value", RecordValue);
     }

--- a/src/SharpAttributeParser/ASemanticArgumentRecorder.cs
+++ b/src/SharpAttributeParser/ASemanticArgumentRecorder.cs
@@ -14,30 +14,14 @@ using System.Collections.Generic;
 /// </list></remarks>
 public abstract class ASemanticArgumentRecorder : ISemanticArgumentRecorder
 {
-    /// <summary>Responsible for recording the argument of a type parameter.</summary>
-    /// <param name="value">The value of the argument.</param>
-    /// <returns>A <see cref="bool"/> indicating whether the argument was successfully recorded.</returns>
-    /// <exception cref="ArgumentNullException"/>
-    protected delegate bool DGenericRecorder(ITypeSymbol value);
-
-    /// <summary>Responsible for recording the argument of a constructor or named parameter.</summary>
-    /// <param name="value">The value of the argument.</param>
-    /// <returns>A <see cref="bool"/> indicating whether the argument was successfully recorded.</returns>
-    protected delegate bool DSingleRecorder(object? value);
-
-    /// <summary>Responsible for recording the array-valued argument of a constructor or named parameter.</summary>
-    /// <param name="value">The value of the argument.</param>
-    /// <returns>A <see cref="bool"/> indicating whether the argument was successfully recorded.</returns>
-    protected delegate bool DArrayRecorder(IReadOnlyList<object?>? value);
-
     /// <summary>Provides adapters that may be applied to parsed arguments before they are recorded.</summary>
     protected static ISemanticAdapterProvider Adapters { get; } = new SemanticAdapterProvider();
 
     private bool IsInitialized { get; set; }
 
-    private IReadOnlyDictionary<string, DGenericRecorder> GenericRecorders { get; set; } = null!;
-    private IReadOnlyDictionary<string, DSingleRecorder> SingleRecorders { get; set; } = null!;
-    private IReadOnlyDictionary<string, DArrayRecorder> ArrayRecorders { get; set; } = null!;
+    private IReadOnlyDictionary<string, DSemanticGenericRecorder> GenericRecorders { get; set; } = null!;
+    private IReadOnlyDictionary<string, DSemanticSingleRecorder> SingleRecorders { get; set; } = null!;
+    private IReadOnlyDictionary<string, DSemanticArrayRecorder> ArrayRecorders { get; set; } = null!;
 
     private void InitializeRecorder()
     {
@@ -47,9 +31,9 @@ public abstract class ASemanticArgumentRecorder : ISemanticArgumentRecorder
         var singleRecorderMappings = AddSingleRecorders() ?? throw new InvalidOperationException($"The provided collection of non-array-valued parameter mappings was null.");
         var arrayRecorderMappings = AddArrayRecorders() ?? throw new InvalidOperationException($"The provided collection of array-valued parameter mappings was null.");
 
-        Dictionary<string, DGenericRecorder> genericRecorderDictionary = new(comparer);
-        Dictionary<string, DSingleRecorder> singleRecorderDictionary = new(comparer);
-        Dictionary<string, DArrayRecorder> arrayRecorderDictionary = new(comparer);
+        Dictionary<string, DSemanticGenericRecorder> genericRecorderDictionary = new(comparer);
+        Dictionary<string, DSemanticSingleRecorder> singleRecorderDictionary = new(comparer);
+        Dictionary<string, DSemanticArrayRecorder> arrayRecorderDictionary = new(comparer);
 
         PopulateDictionary(genericRecorderDictionary, genericRecorderMappings);
         PopulateDictionary(singleRecorderDictionary, singleRecorderMappings);
@@ -97,15 +81,15 @@ public abstract class ASemanticArgumentRecorder : ISemanticArgumentRecorder
 
     /// <summary>Maps the names of type-parameters to recorders, responsible for recording the argument of the parameter.</summary>
     /// <returns>The mappings from parameter names to recorders.</returns>
-    protected virtual IEnumerable<(string, DGenericRecorder)> AddGenericRecorders() => Array.Empty<(string, DGenericRecorder)>();
+    protected virtual IEnumerable<(string, DSemanticGenericRecorder)> AddGenericRecorders() => Array.Empty<(string, DSemanticGenericRecorder)>();
 
     /// <summary>Maps the names of non-array-valued parameters to recorders, responsible for recording the argument of the parameter.</summary>
     /// <returns>The mappings from parameter names to recorders.</returns>
-    protected virtual IEnumerable<(string, DSingleRecorder)> AddSingleRecorders() => Array.Empty<(string, DSingleRecorder)>();
+    protected virtual IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders() => Array.Empty<(string, DSemanticSingleRecorder)>();
 
     /// <summary>Maps the names of array-valued parameters to recorders, responsible for recording the argument of the parameter.</summary>
     /// <returns>The mappings from parameter names to recorders.</returns>
-    protected virtual IEnumerable<(string, DArrayRecorder)> AddArrayRecorders() => Array.Empty<(string, DArrayRecorder)>();
+    protected virtual IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders() => Array.Empty<(string, DSemanticArrayRecorder)>();
 
     /// <inheritdoc/>
     public bool TryRecordGenericArgument(string parameterName, ITypeSymbol value)

--- a/src/SharpAttributeParser/SemanticAdapterProvider.cs
+++ b/src/SharpAttributeParser/SemanticAdapterProvider.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 /// <inheritdoc cref="ISemanticAdapterProvider"/>
 internal sealed class SemanticAdapterProvider : ISemanticAdapterProvider
 {
-    Func<ITypeSymbol, bool> ISemanticAdapterProvider.For(Action<ITypeSymbol> recorder)
+    DSemanticGenericRecorder ISemanticAdapterProvider.For(Action<ITypeSymbol> recorder)
     {
         return wrapper;
 
@@ -20,10 +20,10 @@ internal sealed class SemanticAdapterProvider : ISemanticAdapterProvider
         }
     }
 
-    Func<object?, bool> ISemanticAdapterProvider.For<T>(Func<T, bool> recorder) => For(recorder);
-    Func<IReadOnlyList<object?>?, bool> ISemanticAdapterProvider.For<T>(Func<IReadOnlyList<T>, bool> recorder) => For(recorder);
+    DSemanticSingleRecorder ISemanticAdapterProvider.For<T>(Func<T, bool> recorder) => For(recorder);
+    DSemanticArrayRecorder ISemanticAdapterProvider.For<T>(Func<IReadOnlyList<T>, bool> recorder) => For(recorder);
 
-    Func<object?, bool> ISemanticAdapterProvider.For<T>(Action<T> recorder)
+    DSemanticSingleRecorder ISemanticAdapterProvider.For<T>(Action<T> recorder)
     {
         return For<T>(wrapper);
 
@@ -35,7 +35,7 @@ internal sealed class SemanticAdapterProvider : ISemanticAdapterProvider
         }
     }
 
-    Func<IReadOnlyList<object?>?, bool> ISemanticAdapterProvider.For<T>(Action<IReadOnlyList<T>> recorder)
+    DSemanticArrayRecorder ISemanticAdapterProvider.For<T>(Action<IReadOnlyList<T>> recorder)
     {
         return For<T>(wrapper);
 
@@ -47,13 +47,13 @@ internal sealed class SemanticAdapterProvider : ISemanticAdapterProvider
         }
     }
 
-    Func<object?, bool> ISemanticAdapterProvider.ForNullable<T>(Func<T?, bool> recorder) where T : class => ForNullable(recorder);
-    Func<object?, bool> ISemanticAdapterProvider.ForNullable<T>(Func<T?, bool> recorder) where T : struct => ForNullable(recorder);
+    DSemanticSingleRecorder ISemanticAdapterProvider.ForNullable<T>(Func<T?, bool> recorder) where T : class => ForNullable(recorder);
+    DSemanticSingleRecorder ISemanticAdapterProvider.ForNullable<T>(Func<T?, bool> recorder) where T : struct => ForNullable(recorder);
 
-    Func<IReadOnlyList<object?>?, bool> ISemanticAdapterProvider.ForNullable<T>(Func<IReadOnlyList<T?>?, bool> recorder) where T : class => ForNullable(recorder);
-    Func<IReadOnlyList<object?>?, bool> ISemanticAdapterProvider.ForNullable<T>(Func<IReadOnlyList<T?>?, bool> recorder) where T : struct => ForNullable(recorder);
+    DSemanticArrayRecorder ISemanticAdapterProvider.ForNullable<T>(Func<IReadOnlyList<T?>?, bool> recorder) where T : class => ForNullable(recorder);
+    DSemanticArrayRecorder ISemanticAdapterProvider.ForNullable<T>(Func<IReadOnlyList<T?>?, bool> recorder) where T : struct => ForNullable(recorder);
 
-    Func<object?, bool> ISemanticAdapterProvider.ForNullable<T>(Action<T?> recorder) where T : class
+    DSemanticSingleRecorder ISemanticAdapterProvider.ForNullable<T>(Action<T?> recorder) where T : class
     {
         return ForNullable<T>(wrapper);
 
@@ -65,7 +65,7 @@ internal sealed class SemanticAdapterProvider : ISemanticAdapterProvider
         }
     }
 
-    Func<object?, bool> ISemanticAdapterProvider.ForNullable<T>(Action<T?> recorder) where T : struct
+    DSemanticSingleRecorder ISemanticAdapterProvider.ForNullable<T>(Action<T?> recorder) where T : struct
     {
         return ForNullable<T>(wrapper);
 
@@ -77,7 +77,7 @@ internal sealed class SemanticAdapterProvider : ISemanticAdapterProvider
         }
     }
 
-    Func<IReadOnlyList<object?>?, bool> ISemanticAdapterProvider.ForNullable<T>(Action<IReadOnlyList<T?>?> recorder) where T : class
+    DSemanticArrayRecorder ISemanticAdapterProvider.ForNullable<T>(Action<IReadOnlyList<T?>?> recorder) where T : class
     {
         return ForNullable<T>(wrapper);
 
@@ -89,7 +89,7 @@ internal sealed class SemanticAdapterProvider : ISemanticAdapterProvider
         }
     }
 
-    Func<IReadOnlyList<object?>?, bool> ISemanticAdapterProvider.ForNullable<T>(Action<IReadOnlyList<T?>?> recorder) where T : struct
+    DSemanticArrayRecorder ISemanticAdapterProvider.ForNullable<T>(Action<IReadOnlyList<T?>?> recorder) where T : struct
     {
         return ForNullable<T>(wrapper);
 
@@ -101,10 +101,10 @@ internal sealed class SemanticAdapterProvider : ISemanticAdapterProvider
         }
     }
 
-    Func<IReadOnlyList<object?>?, bool> ISemanticAdapterProvider.ForNullableElements<T>(Func<IReadOnlyList<T?>, bool> recorder) where T : class => ForNullableElements(recorder);
-    Func<IReadOnlyList<object?>?, bool> ISemanticAdapterProvider.ForNullableElements<T>(Func<IReadOnlyList<T?>, bool> recorder) where T : struct => ForNullableElements(recorder);
+    DSemanticArrayRecorder ISemanticAdapterProvider.ForNullableElements<T>(Func<IReadOnlyList<T?>, bool> recorder) where T : class => ForNullableElements(recorder);
+    DSemanticArrayRecorder ISemanticAdapterProvider.ForNullableElements<T>(Func<IReadOnlyList<T?>, bool> recorder) where T : struct => ForNullableElements(recorder);
 
-    Func<IReadOnlyList<object?>?, bool> ISemanticAdapterProvider.ForNullableElements<T>(Action<IReadOnlyList<T?>> recorder) where T : class
+    DSemanticArrayRecorder ISemanticAdapterProvider.ForNullableElements<T>(Action<IReadOnlyList<T?>> recorder) where T : class
     {
         return ForNullableElements<T>(wrapper);
 
@@ -116,7 +116,7 @@ internal sealed class SemanticAdapterProvider : ISemanticAdapterProvider
         }
     }
 
-    Func<IReadOnlyList<object?>?, bool> ISemanticAdapterProvider.ForNullableElements<T>(Action<IReadOnlyList<T?>> recorder) where T : struct
+    DSemanticArrayRecorder ISemanticAdapterProvider.ForNullableElements<T>(Action<IReadOnlyList<T?>> recorder) where T : struct
     {
         return ForNullableElements<T>(wrapper);
 
@@ -128,9 +128,9 @@ internal sealed class SemanticAdapterProvider : ISemanticAdapterProvider
         }
     }
 
-    Func<IReadOnlyList<object?>?, bool> ISemanticAdapterProvider.ForNullableCollection<T>(Func<IReadOnlyList<T>?, bool> recorder) => ForNullableCollection(recorder);
+    DSemanticArrayRecorder ISemanticAdapterProvider.ForNullableCollection<T>(Func<IReadOnlyList<T>?, bool> recorder) => ForNullableCollection(recorder);
 
-    Func<IReadOnlyList<object?>?, bool> ISemanticAdapterProvider.ForNullableCollection<T>(Action<IReadOnlyList<T>?> recorder)
+    DSemanticArrayRecorder ISemanticAdapterProvider.ForNullableCollection<T>(Action<IReadOnlyList<T>?> recorder)
     {
         return ForNullableCollection<T>(wrapper);
 
@@ -142,7 +142,7 @@ internal sealed class SemanticAdapterProvider : ISemanticAdapterProvider
         }
     }
 
-    private static Func<object?, bool> For<T>(Func<T, bool> recorder)
+    private static DSemanticSingleRecorder For<T>(Func<T, bool> recorder)
     {
         return wrapper;
 
@@ -164,7 +164,7 @@ internal sealed class SemanticAdapterProvider : ISemanticAdapterProvider
         }
     }
 
-    private static Func<IReadOnlyList<object?>?, bool> For<T>(Func<IReadOnlyList<T>, bool> recorder)
+    private static DSemanticArrayRecorder For<T>(Func<IReadOnlyList<T>, bool> recorder)
     {
         return wrapper;
 
@@ -198,7 +198,7 @@ internal sealed class SemanticAdapterProvider : ISemanticAdapterProvider
         }
     }
 
-    private static Func<object?, bool> ForNullable<T>(Func<T?, bool> recorder) where T : class
+    private static DSemanticSingleRecorder ForNullable<T>(Func<T?, bool> recorder) where T : class
     {
         return wrapper;
 
@@ -215,7 +215,7 @@ internal sealed class SemanticAdapterProvider : ISemanticAdapterProvider
         }
     }
 
-    private static Func<object?, bool> ForNullable<T>(Func<T?, bool> recorder) where T : struct
+    private static DSemanticSingleRecorder ForNullable<T>(Func<T?, bool> recorder) where T : struct
     {
         return wrapper;
 
@@ -232,7 +232,7 @@ internal sealed class SemanticAdapterProvider : ISemanticAdapterProvider
         }
     }
 
-    private static Func<IReadOnlyList<object?>?, bool> ForNullable<T>(Func<IReadOnlyList<T?>?, bool> recorder) where T : class
+    private static DSemanticArrayRecorder ForNullable<T>(Func<IReadOnlyList<T?>?, bool> recorder) where T : class
     {
         return wrapper;
 
@@ -261,7 +261,7 @@ internal sealed class SemanticAdapterProvider : ISemanticAdapterProvider
         }
     }
 
-    private static Func<IReadOnlyList<object?>?, bool> ForNullable<T>(Func<IReadOnlyList<T?>?, bool> recorder) where T : struct
+    private static DSemanticArrayRecorder ForNullable<T>(Func<IReadOnlyList<T?>?, bool> recorder) where T : struct
     {
         return wrapper;
 
@@ -290,7 +290,7 @@ internal sealed class SemanticAdapterProvider : ISemanticAdapterProvider
         }
     }
 
-    private static Func<IReadOnlyList<object?>?, bool> ForNullableElements<T>(Func<IReadOnlyList<T?>, bool> recorder) where T : class
+    private static DSemanticArrayRecorder ForNullableElements<T>(Func<IReadOnlyList<T?>, bool> recorder) where T : class
     {
         return ForNullable<T>(wrapper);
 
@@ -305,7 +305,7 @@ internal sealed class SemanticAdapterProvider : ISemanticAdapterProvider
         }
     }
 
-    private static Func<IReadOnlyList<object?>?, bool> ForNullableElements<T>(Func<IReadOnlyList<T?>, bool> recorder) where T : struct
+    private static DSemanticArrayRecorder ForNullableElements<T>(Func<IReadOnlyList<T?>, bool> recorder) where T : struct
     {
         return ForNullable<T>(wrapper);
 
@@ -320,7 +320,7 @@ internal sealed class SemanticAdapterProvider : ISemanticAdapterProvider
         }
     }
 
-    private static Func<IReadOnlyList<object?>?, bool> ForNullableCollection<T>(Func<IReadOnlyList<T>?, bool> recorder)
+    private static DSemanticArrayRecorder ForNullableCollection<T>(Func<IReadOnlyList<T>?, bool> recorder)
     {
         return wrapper;
 

--- a/src/SharpAttributeParser/SyntacticAdapterProvider.cs
+++ b/src/SharpAttributeParser/SyntacticAdapterProvider.cs
@@ -17,7 +17,7 @@ internal sealed class SyntacticAdapterProvider : ISyntacticAdapterProvider
         SemanticAdapters = semanticAdapters;
     }
 
-    Func<ITypeSymbol, Location, bool> ISyntacticAdapterProvider.For(Action<ITypeSymbol, Location> recorder)
+    DSyntacticGenericRecorder ISyntacticAdapterProvider.For(Action<ITypeSymbol, Location> recorder)
     {
         return wrapper;
 
@@ -29,7 +29,7 @@ internal sealed class SyntacticAdapterProvider : ISyntacticAdapterProvider
         }
     }
 
-    Func<object?, Location, bool> ISyntacticAdapterProvider.For<T>(Func<T, Location, bool> recorder)
+    DSyntacticSingleRecorder ISyntacticAdapterProvider.For<T>(Func<T, Location, bool> recorder)
     {
         return wrapper;
 
@@ -41,7 +41,7 @@ internal sealed class SyntacticAdapterProvider : ISyntacticAdapterProvider
         }
     }
 
-    Func<IReadOnlyList<object?>?, Location, IReadOnlyList<Location>, bool> ISyntacticAdapterProvider.For<T>(Func<IReadOnlyList<T>, Location, IReadOnlyList<Location>, bool> recorder)
+    DSyntacticArrayRecorder ISyntacticAdapterProvider.For<T>(Func<IReadOnlyList<T>, Location, IReadOnlyList<Location>, bool> recorder)
     {
         return wrapper;
 
@@ -53,7 +53,7 @@ internal sealed class SyntacticAdapterProvider : ISyntacticAdapterProvider
         }
     }
 
-    Func<object?, Location, bool> ISyntacticAdapterProvider.For<T>(Action<T, Location> recorder)
+    DSyntacticSingleRecorder ISyntacticAdapterProvider.For<T>(Action<T, Location> recorder)
     {
         return wrapper;
 
@@ -65,7 +65,7 @@ internal sealed class SyntacticAdapterProvider : ISyntacticAdapterProvider
         }
     }
 
-    Func<IReadOnlyList<object?>?, Location, IReadOnlyList<Location>, bool> ISyntacticAdapterProvider.For<T>(Action<IReadOnlyList<T>, Location, IReadOnlyList<Location>> recorder)
+    DSyntacticArrayRecorder ISyntacticAdapterProvider.For<T>(Action<IReadOnlyList<T>, Location, IReadOnlyList<Location>> recorder)
     {
         return wrapper;
 
@@ -77,7 +77,7 @@ internal sealed class SyntacticAdapterProvider : ISyntacticAdapterProvider
         }
     }
 
-    Func<object?, Location, bool> ISyntacticAdapterProvider.ForNullable<T>(Func<T?, Location, bool> recorder) where T : class
+    DSyntacticSingleRecorder ISyntacticAdapterProvider.ForNullable<T>(Func<T?, Location, bool> recorder) where T : class
     {
         return wrapper;
 
@@ -89,7 +89,7 @@ internal sealed class SyntacticAdapterProvider : ISyntacticAdapterProvider
         }
     }
 
-    Func<object?, Location, bool> ISyntacticAdapterProvider.ForNullable<T>(Func<T?, Location, bool> recorder) where T : struct
+    DSyntacticSingleRecorder ISyntacticAdapterProvider.ForNullable<T>(Func<T?, Location, bool> recorder) where T : struct
     {
         return wrapper;
 
@@ -101,7 +101,7 @@ internal sealed class SyntacticAdapterProvider : ISyntacticAdapterProvider
         }
     }
 
-    Func<IReadOnlyList<object?>?, Location, IReadOnlyList<Location>, bool> ISyntacticAdapterProvider.ForNullable<T>(Func<IReadOnlyList<T?>?, Location, IReadOnlyList<Location>, bool> recorder) where T : class
+    DSyntacticArrayRecorder ISyntacticAdapterProvider.ForNullable<T>(Func<IReadOnlyList<T?>?, Location, IReadOnlyList<Location>, bool> recorder) where T : class
     {
         return wrapper;
 
@@ -113,7 +113,7 @@ internal sealed class SyntacticAdapterProvider : ISyntacticAdapterProvider
         }
     }
 
-    Func<IReadOnlyList<object?>?, Location, IReadOnlyList<Location>, bool> ISyntacticAdapterProvider.ForNullable<T>(Func<IReadOnlyList<T?>?, Location, IReadOnlyList<Location>, bool> recorder) where T : struct
+    DSyntacticArrayRecorder ISyntacticAdapterProvider.ForNullable<T>(Func<IReadOnlyList<T?>?, Location, IReadOnlyList<Location>, bool> recorder) where T : struct
     {
         return wrapper;
 
@@ -125,7 +125,7 @@ internal sealed class SyntacticAdapterProvider : ISyntacticAdapterProvider
         }
     }
 
-    Func<object?, Location, bool> ISyntacticAdapterProvider.ForNullable<T>(Action<T?, Location> recorder) where T : class
+    DSyntacticSingleRecorder ISyntacticAdapterProvider.ForNullable<T>(Action<T?, Location> recorder) where T : class
     {
         return wrapper;
 
@@ -137,7 +137,7 @@ internal sealed class SyntacticAdapterProvider : ISyntacticAdapterProvider
         }
     }
 
-    Func<object?, Location, bool> ISyntacticAdapterProvider.ForNullable<T>(Action<T?, Location> recorder) where T : struct
+    DSyntacticSingleRecorder ISyntacticAdapterProvider.ForNullable<T>(Action<T?, Location> recorder) where T : struct
     {
         return wrapper;
 
@@ -149,7 +149,7 @@ internal sealed class SyntacticAdapterProvider : ISyntacticAdapterProvider
         }
     }
 
-    Func<IReadOnlyList<object?>?, Location, IReadOnlyList<Location>, bool> ISyntacticAdapterProvider.ForNullable<T>(Action<IReadOnlyList<T?>?, Location, IReadOnlyList<Location>> recorder) where T : class
+    DSyntacticArrayRecorder ISyntacticAdapterProvider.ForNullable<T>(Action<IReadOnlyList<T?>?, Location, IReadOnlyList<Location>> recorder) where T : class
     {
         return wrapper;
 
@@ -161,7 +161,7 @@ internal sealed class SyntacticAdapterProvider : ISyntacticAdapterProvider
         }
     }
 
-    Func<IReadOnlyList<object?>?, Location, IReadOnlyList<Location>, bool> ISyntacticAdapterProvider.ForNullable<T>(Action<IReadOnlyList<T?>?, Location, IReadOnlyList<Location>> recorder) where T : struct
+    DSyntacticArrayRecorder ISyntacticAdapterProvider.ForNullable<T>(Action<IReadOnlyList<T?>?, Location, IReadOnlyList<Location>> recorder) where T : struct
     {
         return wrapper;
 
@@ -173,7 +173,7 @@ internal sealed class SyntacticAdapterProvider : ISyntacticAdapterProvider
         }
     }
 
-    Func<IReadOnlyList<object?>?, Location, IReadOnlyList<Location>, bool> ISyntacticAdapterProvider.ForNullableElements<T>(Func<IReadOnlyList<T?>, Location, IReadOnlyList<Location>, bool> recorder) where T : class
+    DSyntacticArrayRecorder ISyntacticAdapterProvider.ForNullableElements<T>(Func<IReadOnlyList<T?>, Location, IReadOnlyList<Location>, bool> recorder) where T : class
     {
         return wrapper;
 
@@ -185,7 +185,7 @@ internal sealed class SyntacticAdapterProvider : ISyntacticAdapterProvider
         }
     }
 
-    Func<IReadOnlyList<object?>?, Location, IReadOnlyList<Location>, bool> ISyntacticAdapterProvider.ForNullableElements<T>(Func<IReadOnlyList<T?>, Location, IReadOnlyList<Location>, bool> recorder) where T : struct
+    DSyntacticArrayRecorder ISyntacticAdapterProvider.ForNullableElements<T>(Func<IReadOnlyList<T?>, Location, IReadOnlyList<Location>, bool> recorder) where T : struct
     {
         return wrapper;
 
@@ -197,7 +197,7 @@ internal sealed class SyntacticAdapterProvider : ISyntacticAdapterProvider
         }
     }
 
-    Func<IReadOnlyList<object?>?, Location, IReadOnlyList<Location>, bool> ISyntacticAdapterProvider.ForNullableElements<T>(Action<IReadOnlyList<T?>, Location, IReadOnlyList<Location>> recorder) where T : class
+    DSyntacticArrayRecorder ISyntacticAdapterProvider.ForNullableElements<T>(Action<IReadOnlyList<T?>, Location, IReadOnlyList<Location>> recorder) where T : class
     {
         return wrapper;
 
@@ -209,7 +209,7 @@ internal sealed class SyntacticAdapterProvider : ISyntacticAdapterProvider
         }
     }
 
-    Func<IReadOnlyList<object?>?, Location, IReadOnlyList<Location>, bool> ISyntacticAdapterProvider.ForNullableElements<T>(Action<IReadOnlyList<T?>, Location, IReadOnlyList<Location>> recorder) where T : struct
+    DSyntacticArrayRecorder ISyntacticAdapterProvider.ForNullableElements<T>(Action<IReadOnlyList<T?>, Location, IReadOnlyList<Location>> recorder) where T : struct
     {
         return wrapper;
 
@@ -221,7 +221,7 @@ internal sealed class SyntacticAdapterProvider : ISyntacticAdapterProvider
         }
     }
 
-    Func<IReadOnlyList<object?>?, Location, IReadOnlyList<Location>, bool> ISyntacticAdapterProvider.ForNullableCollection<T>(Func<IReadOnlyList<T>?, Location, IReadOnlyList<Location>, bool> recorder)
+    DSyntacticArrayRecorder ISyntacticAdapterProvider.ForNullableCollection<T>(Func<IReadOnlyList<T>?, Location, IReadOnlyList<Location>, bool> recorder)
     {
         return wrapper;
 
@@ -233,7 +233,7 @@ internal sealed class SyntacticAdapterProvider : ISyntacticAdapterProvider
         }
     }
 
-    Func<IReadOnlyList<object?>?, Location, IReadOnlyList<Location>, bool> ISyntacticAdapterProvider.ForNullableCollection<T>(Action<IReadOnlyList<T>?, Location, IReadOnlyList<Location>> recorder)
+    DSyntacticArrayRecorder ISyntacticAdapterProvider.ForNullableCollection<T>(Action<IReadOnlyList<T>?, Location, IReadOnlyList<Location>> recorder)
     {
         return wrapper;
 


### PR DESCRIPTION
Added recorder delegates to .Abstractions, so that adapters can return the specialized delegates immediately, rather than Func. Thereby, it is no longer necessary to call .Invoke when registering recorders with the provided abstract recorders.