### PR TITLE
Keep parameter symbol

### DIFF
--- a/src/SharpAttributeParser.Abstractions/ISemanticArgumentRecorder.cs
+++ b/src/SharpAttributeParser.Abstractions/ISemanticArgumentRecorder.cs
@@ -9,31 +9,31 @@ using System.Collections.Generic;
 public interface ISemanticArgumentRecorder
 {
     /// <summary>Attempts to record the argument of a type parameter.</summary>
-    /// <param name="parameterName">The name of the parameter.</param>
+    /// <param name="parameter">The parameter with which the argument is associated.</param>
     /// <param name="value">The value of the argument.</param>
     /// <returns>A <see cref="bool"/> indicating whether the argument was successfully recorded.</returns>
     /// <exception cref="ArgumentException"/>
     /// <exception cref="ArgumentNullException"/>
     /// <exception cref="InvalidOperationException"/>
-    public abstract bool TryRecordGenericArgument(string parameterName, ITypeSymbol value);
+    public abstract bool TryRecordGenericArgument(ITypeParameterSymbol parameter, ITypeSymbol value);
 
     /// <summary>Attempts to record the argument of a constructor parameter.</summary>
-    /// <param name="parameterName">The name of the parameter.</param>
+    /// <param name="parameter">The parameter with which the argument is associated.</param>
     /// <param name="value">The value of the argument.</param>
     /// <returns>A <see cref="bool"/> indicating whether the argument was successfully recorded.</returns>
     /// <exception cref="ArgumentException"/>
     /// <exception cref="ArgumentNullException"/>
     /// <exception cref="InvalidOperationException"/>
-    public abstract bool TryRecordConstructorArgument(string parameterName, object? value);
+    public abstract bool TryRecordConstructorArgument(IParameterSymbol parameter, object? value);
 
     /// <summary>Attempts to record the array-valued argument of a constructor parameter.</summary>
-    /// <param name="parameterName">The name of the parameter.</param>
+    /// <param name="parameter">The parameter with which the argument is associated.</param>
     /// <param name="value">The value of the argument.</param>
     /// <returns>A <see cref="bool"/> indicating whether the argument was successfully recorded.</returns>
     /// <exception cref="ArgumentException"/>
     /// <exception cref="ArgumentNullException"/>
     /// <exception cref="InvalidOperationException"/>
-    public abstract bool TryRecordConstructorArgument(string parameterName, IReadOnlyList<object?>? value);
+    public abstract bool TryRecordConstructorArgument(IParameterSymbol parameter, IReadOnlyList<object?>? value);
 
     /// <summary>Attempts to record the argument of a named parameter.</summary>
     /// <param name="parameterName">The name of the parameter.</param>

--- a/src/SharpAttributeParser.Abstractions/ISyntacticArgumentRecorder.cs
+++ b/src/SharpAttributeParser.Abstractions/ISyntacticArgumentRecorder.cs
@@ -9,27 +9,27 @@ using System.Collections.Generic;
 public interface ISyntacticArgumentRecorder
 {
     /// <summary>Attempts to record the argument of a type parameter.</summary>
-    /// <param name="parameterName">The name of the parameter.</param>
+    /// <param name="parameter">The parameter with which the argument is associated.</param>
     /// <param name="value">The value of the argument.</param>
     /// <param name="location">The <see cref="Location"/> of the argument.</param>
     /// <returns>A <see cref="bool"/> indicating whether the argument was successfully recorded.</returns>
     /// <exception cref="ArgumentException"/>
     /// <exception cref="ArgumentNullException"/>
     /// <exception cref="InvalidOperationException"/>
-    public abstract bool TryRecordGenericArgument(string parameterName, ITypeSymbol value, Location location);
+    public abstract bool TryRecordGenericArgument(ITypeParameterSymbol parameter, ITypeSymbol value, Location location);
 
     /// <summary>Attempts to record the argument of a constructor parameter.</summary>
-    /// <param name="parameterName">The name of the parameter.</param>
+    /// <param name="parameter">The parameter with which the argument is associated.</param>
     /// <param name="value">The value of the constructor argument.</param>
     /// <param name="location">The <see cref="Location"/> of the argument.</param>
     /// <returns>A <see cref="bool"/> indicating whether the argument was successfully recorded.</returns>
     /// <exception cref="ArgumentException"/>
     /// <exception cref="ArgumentNullException"/>
     /// <exception cref="InvalidOperationException"/>
-    public abstract bool TryRecordConstructorArgument(string parameterName, object? value, Location location);
+    public abstract bool TryRecordConstructorArgument(IParameterSymbol parameter, object? value, Location location);
 
     /// <summary>Attempts to record the array-valued argument of a constructor parameter.</summary>
-    /// <param name="parameterName">The name of the parameter.</param>
+    /// <param name="parameter">The parameter with which the argument is associated.</param>
     /// <param name="value">The value of the argument.</param>
     /// <param name="collectionLocation">The <see cref="Location"/> of the entire argument.</param>
     /// <param name="elementLocations">The <see cref="Location"/> of the individual elements in the array-valued argument.</param>
@@ -37,7 +37,7 @@ public interface ISyntacticArgumentRecorder
     /// <exception cref="ArgumentException"/>
     /// <exception cref="ArgumentNullException"/>
     /// <exception cref="InvalidOperationException"/>
-    public abstract bool TryRecordConstructorArgument(string parameterName, IReadOnlyList<object?>? value, Location collectionLocation, IReadOnlyList<Location> elementLocations);
+    public abstract bool TryRecordConstructorArgument(IParameterSymbol parameter, IReadOnlyList<object?>? value, Location collectionLocation, IReadOnlyList<Location> elementLocations);
 
     /// <summary>Attempts to record the argument of a named parameter.</summary>
     /// <param name="parameterName">The name of the parameter.</param>

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullableCollection_Action.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullableCollection_Action.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 public class ForNullableCollection_Action
 {
-    private static bool TryRecordConstructorArgument(ASemanticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordConstructorArgument(parameterName, value);
+    private static bool TryRecordConstructorArgument(ASemanticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordNamedArgument(parameterName, value);
 
     [Fact]
     public void Enum_SameType_True_RecorderPopulated()

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullableCollection_Func.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullableCollection_Func.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 public class ForNullableCollection_Func
 {
-    private static bool TryRecordConstructorArgument(ASemanticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordConstructorArgument(parameterName, value);
+    private static bool TryRecordConstructorArgument(ASemanticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordNamedArgument(parameterName, value);
 
     [Fact]
     public void Enum_SameType_True_RecorderPopulated()

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullableElements_Action_Class.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullableElements_Action_Class.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 public class ForNullableElements_Action_Class
 {
-    private static bool TryRecordConstructorArgument(ASemanticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordConstructorArgument(parameterName, value);
+    private static bool TryRecordConstructorArgument(ASemanticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordNamedArgument(parameterName, value);
 
     [Fact]
     public void String_String_True_RecorderPopulated()

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullableElements_Action_Struct.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullableElements_Action_Struct.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 public class ForNullableElements_Action_Struct
 {
-    private static bool TryRecordConstructorArgument(ASemanticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordConstructorArgument(parameterName, value);
+    private static bool TryRecordConstructorArgument(ASemanticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordNamedArgument(parameterName, value);
 
     [Fact]
     public void Enum_SameType_True_RecorderPopulated()

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullableElements_Func_Class.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullableElements_Func_Class.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 public class ForNullableElements_Func_Class
 {
-    private static bool TryRecordConstructorArgument(ASemanticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordConstructorArgument(parameterName, value);
+    private static bool TryRecordConstructorArgument(ASemanticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordNamedArgument(parameterName, value);
 
     [Fact]
     public void String_String_True_RecorderPopulated()

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullableElements_Func_Struct.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullableElements_Func_Struct.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 public class ForNullableElements_Func_Struct
 {
-    private static bool TryRecordConstructorArgument(ASemanticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordConstructorArgument(parameterName, value);
+    private static bool TryRecordConstructorArgument(ASemanticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordNamedArgument(parameterName, value);
 
     [Fact]
     public void Enum_SameType_True_RecorderPopulated()

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Action_Array_Class.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Action_Array_Class.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 public class ForNullable_Action_Array_Class
 {
-    private static bool TryRecordConstructorArgument(ASemanticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordConstructorArgument(parameterName, value);
+    private static bool TryRecordConstructorArgument(ASemanticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordNamedArgument(parameterName, value);
 
     [Fact]
     public void String_String_True_RecorderPopulated()

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Action_Array_Struct.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Action_Array_Struct.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 public class ForNullable_Action_Array_Struct
 {
-    private static bool TryRecordConstructorArgument(ASemanticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordConstructorArgument(parameterName, value);
+    private static bool TryRecordConstructorArgument(ASemanticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordNamedArgument(parameterName, value);
 
     [Fact]
     public void Enum_SameType_True_RecorderPopulated()

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Action_Single_Class.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Action_Single_Class.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 public class ForNullable_Action_Single_Class
 {
-    private static bool TryRecordConstructorArgument(ASemanticArgumentRecorder recorder, string parameterName, object? value) => recorder.TryRecordConstructorArgument(parameterName, value);
+    private static bool TryRecordConstructorArgument(ASemanticArgumentRecorder recorder, string parameterName, object? value) => recorder.TryRecordNamedArgument(parameterName, value);
 
     [Fact]
     public void IntArray_IntArray_True_RecorderPopulated()

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Action_Single_Struct.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Action_Single_Struct.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 public class ForNullable_Action_Single_Struct
 {
-    private static bool TryRecordConstructorArgument(ASemanticArgumentRecorder recorder, string parameterName, object? value) => recorder.TryRecordConstructorArgument(parameterName, value);
+    private static bool TryRecordConstructorArgument(ASemanticArgumentRecorder recorder, string parameterName, object? value) => recorder.TryRecordNamedArgument(parameterName, value);
 
     [Fact]
     public void Enum_SameType_True_RecorderPopulated()

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Func_Array_Class.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Func_Array_Class.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 public class ForNullable_Func_Array_Class
 {
-    private static bool TryRecordConstructorArgument(ASemanticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordConstructorArgument(parameterName, value);
+    private static bool TryRecordConstructorArgument(ASemanticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordNamedArgument(parameterName, value);
 
     [Fact]
     public void String_String_True_RecorderPopulated()

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Func_Array_Struct.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Func_Array_Struct.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 public class ForNullable_Func_Array_Struct
 {
-    private static bool TryRecordConstructorArgument(ASemanticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordConstructorArgument(parameterName, value);
+    private static bool TryRecordConstructorArgument(ASemanticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordNamedArgument(parameterName, value);
 
     [Fact]
     public void Enum_SameType_True_RecorderPopulated()

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Func_Single_Class.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Func_Single_Class.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 public class ForNullable_Func_Single_Class
 {
-    private static bool TryRecordConstructorArgument(ASemanticArgumentRecorder recorder, string parameterName, object? value) => recorder.TryRecordConstructorArgument(parameterName, value);
+    private static bool TryRecordConstructorArgument(ASemanticArgumentRecorder recorder, string parameterName, object? value) => recorder.TryRecordNamedArgument(parameterName, value);
 
     [Fact]
     public void IntArray_IntArray_True_RecorderPopulated()

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Func_Single_Struct.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/ForNullable_Func_Single_Struct.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 public class ForNullable_Func_Single_Struct
 {
-    private static bool TryRecordConstructorArgument(ASemanticArgumentRecorder recorder, string parameterName, object? value) => recorder.TryRecordConstructorArgument(parameterName, value);
+    private static bool TryRecordConstructorArgument(ASemanticArgumentRecorder recorder, string parameterName, object? value) => recorder.TryRecordNamedArgument(parameterName, value);
 
     [Fact]
     public void Enum_SameType_True_RecorderPopulated()

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/For_Action_Array.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/For_Action_Array.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 public class For_Action_Array
 {
-    private static bool TryRecordConstructorArgument(ASemanticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordConstructorArgument(parameterName, value);
+    private static bool TryRecordConstructorArgument(ASemanticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordNamedArgument(parameterName, value);
 
     [Fact]
     public void Enum_SameType_True_RecorderPopulated()

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/For_Action_Single.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/For_Action_Single.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 public class For_Action_Single
 {
-    private static bool TryRecordConstructorArgument(ASemanticArgumentRecorder recorder, string parameterName, object? value) => recorder.TryRecordConstructorArgument(parameterName, value);
+    private static bool TryRecordConstructorArgument(ASemanticArgumentRecorder recorder, string parameterName, object? value) => recorder.TryRecordNamedArgument(parameterName, value);
 
     [Fact]
     public void Enum_SameType_True_RecorderPopulated()

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/For_Func_Array.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/For_Func_Array.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 public class For_Func_Array
 {
-    private static bool TryRecordConstructorArgument(ASemanticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordConstructorArgument(parameterName, value);
+    private static bool TryRecordConstructorArgument(ASemanticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordNamedArgument(parameterName, value);
 
     [Fact]
     public void Enum_SameType_True_RecorderPopulated()

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/For_Func_Single.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/For_Func_Single.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 public class For_Func_Single
 {
-    private static bool TryRecordConstructorArgument(ASemanticArgumentRecorder recorder, string parameterName, object? value) => recorder.TryRecordConstructorArgument(parameterName, value);
+    private static bool TryRecordConstructorArgument(ASemanticArgumentRecorder recorder, string parameterName, object? value) => recorder.TryRecordNamedArgument(parameterName, value);
 
     [Fact]
     public void Enum_SameType_True_RecorderPopulated()

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/For_Generic.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/AdapterCases/For_Generic.cs
@@ -12,7 +12,14 @@ using Xunit;
 
 public class For_Generic
 {
-    private static bool TryRecordGenericArgument(ASemanticArgumentRecorder recorder, string parameterName, ITypeSymbol value) => recorder.TryRecordGenericArgument(parameterName, value);
+    private static bool TryRecordGenericArgument(ASemanticArgumentRecorder recorder, string parameterName, ITypeSymbol value)
+    {
+        Mock<ITypeParameterSymbol> parameterMock = new();
+
+        parameterMock.SetupGet(static (parameter) => parameter.Name).Returns(parameterName);
+
+        return recorder.TryRecordGenericArgument(parameterMock.Object, value);
+    }
 
     [Fact]
     public void True_RecordedPopulated()

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/Comparer.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/Comparer.cs
@@ -9,9 +9,9 @@ using Xunit;
 
 public class Comparer
 {
-    private static void TryRecordGenericArgument(ASemanticArgumentRecorder recorder, string parameterName, ITypeSymbol value) => recorder.TryRecordGenericArgument(parameterName, value);
-    private static void TryRecordConstructorArgument(ASemanticArgumentRecorder recorder, string parameterName, object? value) => recorder.TryRecordConstructorArgument(parameterName, value);
-    private static void TryRecordConstructorArgument(ASemanticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordConstructorArgument(parameterName, value);
+    private static void TryRecordGenericArgument(ASemanticArgumentRecorder recorder, ITypeParameterSymbol parameter, ITypeSymbol value) => recorder.TryRecordGenericArgument(parameter, value);
+    private static void TryRecordConstructorArgument(ASemanticArgumentRecorder recorder, IParameterSymbol parameter, object? value) => recorder.TryRecordConstructorArgument(parameter, value);
+    private static void TryRecordConstructorArgument(ASemanticArgumentRecorder recorder, IParameterSymbol parameter, IReadOnlyList<object?>? value) => recorder.TryRecordConstructorArgument(parameter, value);
     private static void TryRecordNamedArgument(ASemanticArgumentRecorder recorder, string parameterName, object? value) => recorder.TryRecordNamedArgument(parameterName, value);
     private static void TryRecordNamedArgument(ASemanticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordNamedArgument(parameterName, value);
 
@@ -22,10 +22,10 @@ public class Comparer
 
         SemanticArgumentRecorder recorder = new(comparer);
 
-        var parameterName = Datasets.GetValidParameterName();
+        var parameter = Datasets.GetMockedTypeParameter();
         var value = Datasets.GetValidTypeSymbol();
 
-        var exception = Record.Exception(() => TryRecordGenericArgument(recorder, parameterName, value));
+        var exception = Record.Exception(() => TryRecordGenericArgument(recorder, parameter, value));
 
         Assert.IsType<InvalidOperationException>(exception);
     }
@@ -37,10 +37,10 @@ public class Comparer
 
         SemanticArgumentRecorder recorder = new(comparerMock.Object);
 
-        var parameterName = Datasets.GetValidParameterName();
+        var parameter = Datasets.GetMockedTypeParameter();
         var value = Datasets.GetValidTypeSymbol();
 
-        TryRecordGenericArgument(recorder, parameterName, value);
+        TryRecordGenericArgument(recorder, parameter, value);
 
         ComparerMock.VerifyInvoked(comparerMock);
     }
@@ -52,10 +52,10 @@ public class Comparer
 
         SemanticArgumentRecorder recorder = new(comparerMock.Object);
 
-        var parameterName = Datasets.GetValidParameterName();
+        var parameter = Datasets.GetMockedParameter();
         var value = Datasets.GetValidTypeSymbol();
 
-        TryRecordConstructorArgument(recorder, parameterName, value);
+        TryRecordConstructorArgument(recorder, parameter, value);
 
         ComparerMock.VerifyInvoked(comparerMock);
     }
@@ -67,10 +67,10 @@ public class Comparer
 
         SemanticArgumentRecorder recorder = new(comparerMock.Object);
 
-        var parameterName = Datasets.GetValidParameterName();
+        var parameter = Datasets.GetMockedParameter();
         var value = new[] { Datasets.GetValidTypeSymbol() };
 
-        TryRecordConstructorArgument(recorder, parameterName, value);
+        TryRecordConstructorArgument(recorder, parameter, value);
 
         ComparerMock.VerifyInvoked(comparerMock);
     }

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/Datasets.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/Datasets.cs
@@ -11,6 +11,28 @@ internal static class Datasets
     public static string GetValidParameterName() => "Bar";
     public static string GetNullParameterName() => null!;
 
+    public static ITypeParameterSymbol GetMockedTypeParameter()
+    {
+        Mock<ITypeParameterSymbol> mock = new();
+
+        mock.SetupGet(static (parameter) => parameter.Name).Returns("Bar");
+
+        return mock.Object;
+    }
+
+    public static ITypeParameterSymbol GetNullTypeParameter() => null!;
+
+    public static IParameterSymbol GetMockedParameter()
+    {
+        Mock<IParameterSymbol> mock = new();
+
+        mock.SetupGet(static (parameter) => parameter.Name).Returns("Bar");
+
+        return mock.Object;
+    }
+
+    public static IParameterSymbol GetNullParameter() => null!;
+
     public static ITypeSymbol GetValidTypeSymbol() => new Mock<ITypeSymbol>().Object;
     public static ITypeSymbol GetNullTypeSymbol() => null!;
 

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/TryRecordConstructorArgument_Array.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/TryRecordConstructorArgument_Array.cs
@@ -1,5 +1,7 @@
 ﻿namespace SharpAttributeParser.Tests.ASemanticArgumentRecorderCases;
 
+using Microsoft.CodeAnalysis;
+
 using System;
 using System.Collections.Generic;
 
@@ -7,17 +9,17 @@ using Xunit;
 
 public class TryRecordConstructorArgument_Array
 {
-    private static bool Target(ASemanticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordConstructorArgument(parameterName, value);
+    private static bool Target(ASemanticArgumentRecorder recorder, IParameterSymbol parameter, IReadOnlyList<object?>? value) => recorder.TryRecordConstructorArgument(parameter, value);
 
     [Fact]
     public void NullParameterName_ArgumentNullException()
     {
         SemanticArgumentRecorder recorder = new(StringComparer.OrdinalIgnoreCase);
 
-        var parameterName = Datasets.GetNullParameterName();
+        var parameter = Datasets.GetNullParameter();
         var value = Datasets.GetValidArrayArgument();
 
-        var exception = Record.Exception(() => Target(recorder, parameterName, value));
+        var exception = Record.Exception(() => Target(recorder, parameter, value));
 
         Assert.IsType<ArgumentNullException>(exception);
     }
@@ -29,10 +31,10 @@ public class TryRecordConstructorArgument_Array
 
         SemanticArgumentRecorder recorder = new(comparerMock.Object);
 
-        var parameterName = Datasets.GetValidParameterName();
+        var parameter = Datasets.GetMockedParameter();
         var value = Datasets.GetNullArrayArgument();
 
-        var actual = Target(recorder, parameterName, value);
+        var actual = Target(recorder, parameter, value);
 
         Assert.True(actual);
 
@@ -47,10 +49,10 @@ public class TryRecordConstructorArgument_Array
 
         SemanticArgumentRecorder recorder = new(comparerMock.Object);
 
-        var parameterName = Datasets.GetValidParameterName();
+        var parameter = Datasets.GetMockedParameter();
         var value = Datasets.GetValidArrayArgument();
 
-        var actual = Target(recorder, parameterName, value);
+        var actual = Target(recorder, parameter, value);
 
         Assert.True(actual);
 
@@ -65,10 +67,10 @@ public class TryRecordConstructorArgument_Array
 
         SemanticArgumentRecorder recorder = new(comparerMock.Object);
 
-        var parameterName = Datasets.GetValidParameterName();
+        var parameter = Datasets.GetMockedParameter();
         var value = Datasets.GetValidArrayArgument();
 
-        var actual = Target(recorder, parameterName, value);
+        var actual = Target(recorder, parameter, value);
 
         Assert.False(actual);
 

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/TryRecordConstructorArgument_Single.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/TryRecordConstructorArgument_Single.cs
@@ -1,22 +1,24 @@
 ﻿namespace SharpAttributeParser.Tests.ASemanticArgumentRecorderCases;
 
+using Microsoft.CodeAnalysis;
+
 using System;
 
 using Xunit;
 
 public class TryRecordConstructorArgument_Single
 {
-    private static bool Target(ASemanticArgumentRecorder recorder, string parameterName, object? value) => recorder.TryRecordConstructorArgument(parameterName, value);
+    private static bool Target(ASemanticArgumentRecorder recorder, IParameterSymbol parameter, object? value) => recorder.TryRecordConstructorArgument(parameter, value);
 
     [Fact]
     public void NullParameterName_ArgumentNullException()
     {
         SemanticArgumentRecorder recorder = new(StringComparer.OrdinalIgnoreCase);
 
-        var parameterName = Datasets.GetNullParameterName();
+        var parameter = Datasets.GetNullParameter();
         var value = Datasets.GetValidTypeSymbol();
 
-        var exception = Record.Exception(() => Target(recorder, parameterName, value));
+        var exception = Record.Exception(() => Target(recorder, parameter, value));
 
         Assert.IsType<ArgumentNullException>(exception);
     }
@@ -28,10 +30,10 @@ public class TryRecordConstructorArgument_Single
 
         SemanticArgumentRecorder recorder = new(comparerMock.Object);
 
-        var parameterName = Datasets.GetValidParameterName();
+        var parameter = Datasets.GetMockedParameter();
         var value = Datasets.GetNullTypeSymbol();
 
-        var actual = Target(recorder, parameterName, value);
+        var actual = Target(recorder, parameter, value);
 
         Assert.True(actual);
 
@@ -46,10 +48,10 @@ public class TryRecordConstructorArgument_Single
 
         SemanticArgumentRecorder recorder = new(comparerMock.Object);
 
-        var parameterName = Datasets.GetValidParameterName();
+        var parameter = Datasets.GetMockedParameter();
         var value = Datasets.GetValidTypeSymbol();
 
-        var actual = Target(recorder, parameterName, value);
+        var actual = Target(recorder, parameter, value);
 
         Assert.True(actual);
 
@@ -64,10 +66,10 @@ public class TryRecordConstructorArgument_Single
 
         SemanticArgumentRecorder recorder = new(comparerMock.Object);
 
-        var parameterName = Datasets.GetValidParameterName();
+        var parameter = Datasets.GetMockedParameter();
         var value = Datasets.GetValidTypeSymbol();
 
-        var actual = Target(recorder, parameterName, value);
+        var actual = Target(recorder, parameter, value);
 
         Assert.False(actual);
 

--- a/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/TryRecordGenericArgument.cs
+++ b/src/SharpAttributeParser.Tests/ASemanticArgumentRecorderCases/TryRecordGenericArgument.cs
@@ -8,17 +8,17 @@ using Xunit;
 
 public class TryRecordGenericArgument
 {
-    private static bool Target(ASemanticArgumentRecorder recorder, string parameterName, ITypeSymbol value) => recorder.TryRecordGenericArgument(parameterName, value);
+    private static bool Target(ASemanticArgumentRecorder recorder, ITypeParameterSymbol parameter, ITypeSymbol value) => recorder.TryRecordGenericArgument(parameter, value);
 
     [Fact]
-    public void NullParameterName_ArgumentNullException()
+    public void NullParameter_ArgumentNullException()
     {
         SemanticArgumentRecorder recorder = new(StringComparer.OrdinalIgnoreCase);
 
-        var parameterName = Datasets.GetNullParameterName();
+        var parameter = Datasets.GetNullTypeParameter();
         var value = Datasets.GetValidTypeSymbol();
 
-        var exception = Record.Exception(() => Target(recorder, parameterName, value));
+        var exception = Record.Exception(() => Target(recorder, parameter, value));
 
         Assert.IsType<ArgumentNullException>(exception);
     }
@@ -28,10 +28,10 @@ public class TryRecordGenericArgument
     {
         SemanticArgumentRecorder recorder = new(StringComparer.OrdinalIgnoreCase);
 
-        var parameterName = Datasets.GetValidParameterName();
+        var parameter = Datasets.GetMockedTypeParameter();
         var value = Datasets.GetNullTypeSymbol();
 
-        var exception = Record.Exception(() => Target(recorder, parameterName, value));
+        var exception = Record.Exception(() => Target(recorder, parameter, value));
 
         Assert.IsType<ArgumentNullException>(exception);
     }
@@ -43,10 +43,10 @@ public class TryRecordGenericArgument
 
         SemanticArgumentRecorder recorder = new(comparerMock.Object);
 
-        var parameterName = Datasets.GetValidParameterName();
+        var parameter = Datasets.GetMockedTypeParameter();
         var value = Datasets.GetValidTypeSymbol();
 
-        var actual = Target(recorder, parameterName, value);
+        var actual = Target(recorder, parameter, value);
 
         Assert.True(actual);
 
@@ -60,10 +60,10 @@ public class TryRecordGenericArgument
 
         SemanticArgumentRecorder recorder = new(comparerMock.Object);
 
-        var parameterName = Datasets.GetValidParameterName();
+        var parameter = Datasets.GetMockedTypeParameter();
         var value = Datasets.GetValidTypeSymbol();
 
-        var actual = Target(recorder, parameterName, value);
+        var actual = Target(recorder, parameter, value);
 
         Assert.False(actual);
 

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullableCollection_Action.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullableCollection_Action.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 public class ForNullableCollection_Action
 {
-    private static bool TryRecordConstructorArgument(ASyntacticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordConstructorArgument(parameterName, value, Location.None, Array.Empty<Location>());
+    private static bool TryRecordConstructorArgument(ASyntacticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordNamedArgument(parameterName, value, Location.None, Array.Empty<Location>());
 
     [Fact]
     public void Enum_SameType_True_RecorderPopulated()

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullableCollection_Func.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullableCollection_Func.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 public class ForNullableCollection_Func
 {
-    private static bool TryRecordConstructorArgument(ASyntacticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordConstructorArgument(parameterName, value, Location.None, Array.Empty<Location>());
+    private static bool TryRecordConstructorArgument(ASyntacticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordNamedArgument(parameterName, value, Location.None, Array.Empty<Location>());
 
     [Fact]
     public void Enum_SameType_True_RecorderPopulated()

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullableElements_Action_Class.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullableElements_Action_Class.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 public class ForNullableElements_Action_Class
 {
-    private static bool TryRecordConstructorArgument(ASyntacticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordConstructorArgument(parameterName, value, Location.None, Array.Empty<Location>());
+    private static bool TryRecordConstructorArgument(ASyntacticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordNamedArgument(parameterName, value, Location.None, Array.Empty<Location>());
 
     [Fact]
     public void String_String_True_RecorderPopulated()

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullableElements_Action_Struct.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullableElements_Action_Struct.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 public class ForNullableElements_Action_Struct
 {
-    private static bool TryRecordConstructorArgument(ASyntacticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordConstructorArgument(parameterName, value, Location.None, Array.Empty<Location>());
+    private static bool TryRecordConstructorArgument(ASyntacticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordNamedArgument(parameterName, value, Location.None, Array.Empty<Location>());
 
     [Fact]
     public void Enum_SameType_True_RecorderPopulated()

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullableElements_Func_Class.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullableElements_Func_Class.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 public class ForNullableElements_Func_Class
 {
-    private static bool TryRecordConstructorArgument(ASyntacticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordConstructorArgument(parameterName, value, Location.None, Array.Empty<Location>());
+    private static bool TryRecordConstructorArgument(ASyntacticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordNamedArgument(parameterName, value, Location.None, Array.Empty<Location>());
 
     [Fact]
     public void String_String_True_RecorderPopulated()

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullableElements_Func_Struct.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullableElements_Func_Struct.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 public class ForNullableElements_Func_Struct
 {
-    private static bool TryRecordConstructorArgument(ASyntacticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordConstructorArgument(parameterName, value, Location.None, Array.Empty<Location>());
+    private static bool TryRecordConstructorArgument(ASyntacticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordNamedArgument(parameterName, value, Location.None, Array.Empty<Location>());
 
     [Fact]
     public void Enum_SameType_True_RecorderPopulated()

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Action_Array_Class.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Action_Array_Class.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 public class ForNullable_Action_Array_Class
 {
-    private static bool TryRecordConstructorArgument(ASyntacticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordConstructorArgument(parameterName, value, Location.None, Array.Empty<Location>());
+    private static bool TryRecordConstructorArgument(ASyntacticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordNamedArgument(parameterName, value, Location.None, Array.Empty<Location>());
 
     [Fact]
     public void String_String_True_RecorderPopulated()

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Action_Array_Struct.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Action_Array_Struct.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 public class ForNullable_Action_Array_Struct
 {
-    private static bool TryRecordConstructorArgument(ASyntacticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordConstructorArgument(parameterName, value, Location.None, Array.Empty<Location>());
+    private static bool TryRecordConstructorArgument(ASyntacticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordNamedArgument(parameterName, value, Location.None, Array.Empty<Location>());
 
     [Fact]
     public void Enum_SameType_True_RecorderPopulated()

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Action_Single_Class.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Action_Single_Class.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 public class ForNullable_Action_Single_Class
 {
-    private static bool TryRecordConstructorArgument(ASyntacticArgumentRecorder recorder, string parameterName, object? value) => recorder.TryRecordConstructorArgument(parameterName, value, Location.None);
+    private static bool TryRecordConstructorArgument(ASyntacticArgumentRecorder recorder, string parameterName, object? value) => recorder.TryRecordNamedArgument(parameterName, value, Location.None);
 
     [Fact]
     public void IntArray_IntArray_True_RecorderPopulated()

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Action_Single_Struct.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Action_Single_Struct.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 public class ForNullable_Action_Single_Struct
 {
-    private static bool TryRecordConstructorArgument(ASyntacticArgumentRecorder recorder, string parameterName, object? value) => recorder.TryRecordConstructorArgument(parameterName, value, Location.None);
+    private static bool TryRecordConstructorArgument(ASyntacticArgumentRecorder recorder, string parameterName, object? value) => recorder.TryRecordNamedArgument(parameterName, value, Location.None);
 
     [Fact]
     public void Enum_SameType_True_RecorderPopulated()

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Func_Array_Class.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Func_Array_Class.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 public class ForNullable_Func_Array_Class
 {
-    private static bool TryRecordConstructorArgument(ASyntacticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordConstructorArgument(parameterName, value, Location.None, Array.Empty<Location>());
+    private static bool TryRecordConstructorArgument(ASyntacticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordNamedArgument(parameterName, value, Location.None, Array.Empty<Location>());
 
     [Fact]
     public void String_String_True_RecorderPopulated()

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Func_Array_Struct.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Func_Array_Struct.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 public class ForNullable_Func_Array_Struct
 {
-    private static bool TryRecordConstructorArgument(ASyntacticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordConstructorArgument(parameterName, value, Location.None, Array.Empty<Location>());
+    private static bool TryRecordConstructorArgument(ASyntacticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordNamedArgument(parameterName, value, Location.None, Array.Empty<Location>());
 
     [Fact]
     public void Enum_SameType_True_RecorderPopulated()

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Func_Single_Class.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Func_Single_Class.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 public class ForNullable_Func_Single_Class
 {
-    private static bool TryRecordConstructorArgument(ASyntacticArgumentRecorder recorder, string parameterName, object? value) => recorder.TryRecordConstructorArgument(parameterName, value, Location.None);
+    private static bool TryRecordConstructorArgument(ASyntacticArgumentRecorder recorder, string parameterName, object? value) => recorder.TryRecordNamedArgument(parameterName, value, Location.None);
 
     [Fact]
     public void IntArray_IntArray_True_RecorderPopulated()

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Func_Single_Struct.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/ForNullable_Func_Single_Struct.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 public class ForNullable_Func_Single_Struct
 {
-    private static bool TryRecordConstructorArgument(ASyntacticArgumentRecorder recorder, string parameterName, object? value) => recorder.TryRecordConstructorArgument(parameterName, value, Location.None);
+    private static bool TryRecordConstructorArgument(ASyntacticArgumentRecorder recorder, string parameterName, object? value) => recorder.TryRecordNamedArgument(parameterName, value, Location.None);
 
     [Fact]
     public void Enum_SameType_True_RecorderPopulated()

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/For_Action_Array.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/For_Action_Array.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 public class For_Action_Array
 {
-    private static bool TryRecordConstructorArgument(ASyntacticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordConstructorArgument(parameterName, value, Location.None, Array.Empty<Location>());
+    private static bool TryRecordConstructorArgument(ASyntacticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordNamedArgument(parameterName, value, Location.None, Array.Empty<Location>());
 
     [Fact]
     public void Enum_SameType_True_RecorderPopulated()

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/For_Action_Single.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/For_Action_Single.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 public class For_Action_Single
 {
-    private static bool TryRecordConstructorArgument(ASyntacticArgumentRecorder recorder, string parameterName, object? value) => recorder.TryRecordConstructorArgument(parameterName, value, Location.None);
+    private static bool TryRecordConstructorArgument(ASyntacticArgumentRecorder recorder, string parameterName, object? value) => recorder.TryRecordNamedArgument(parameterName, value, Location.None);
 
     [Fact]
     public void Enum_SameType_True_RecorderPopulated()

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/For_Func_Array.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/For_Func_Array.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 public class For_Func_Array
 {
-    private static bool TryRecordConstructorArgument(ASyntacticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordConstructorArgument(parameterName, value, Location.None, Array.Empty<Location>());
+    private static bool TryRecordConstructorArgument(ASyntacticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value) => recorder.TryRecordNamedArgument(parameterName, value, Location.None, Array.Empty<Location>());
 
     [Fact]
     public void Enum_SameType_True_RecorderPopulated()

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/For_Func_Single.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/For_Func_Single.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 public class For_Func_Single
 {
-    private static bool TryRecordConstructorArgument(ASyntacticArgumentRecorder recorder, string parameterName, object? value) => recorder.TryRecordConstructorArgument(parameterName, value, Location.None);
+    private static bool TryRecordConstructorArgument(ASyntacticArgumentRecorder recorder, string parameterName, object? value) => recorder.TryRecordNamedArgument(parameterName, value, Location.None);
 
     [Fact]
     public void Enum_SameType_True_RecorderPopulated()

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/For_Generic.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/AdapterCases/For_Generic.cs
@@ -12,7 +12,14 @@ using Xunit;
 
 public class For_Generic
 {
-    private static bool TryRecordGenericArgument(ASyntacticArgumentRecorder recorder, string parameterName, ITypeSymbol value) => recorder.TryRecordGenericArgument(parameterName, value, Location.None);
+    private static bool TryRecordGenericArgument(ASyntacticArgumentRecorder recorder, string parameterName, ITypeSymbol value)
+    {
+        Mock<ITypeParameterSymbol> parameterMock = new();
+
+        parameterMock.SetupGet(static (parameter) => parameter.Name).Returns(parameterName);
+
+        return recorder.TryRecordGenericArgument(parameterMock.Object, value, Location.None);
+    }
 
     [Fact]
     public void True_RecordedPopulated()

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/Comparer.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/Comparer.cs
@@ -9,9 +9,9 @@ using Xunit;
 
 public class Comparer
 {
-    private static void TryRecordGenericArgument(ASyntacticArgumentRecorder recorder, string parameterName, ITypeSymbol value, Location location) => recorder.TryRecordGenericArgument(parameterName, value, location);
-    private static void TryRecordConstructorArgument(ASyntacticArgumentRecorder recorder, string parameterName, object? value, Location location) => recorder.TryRecordConstructorArgument(parameterName, value, location);
-    private static void TryRecordConstructorArgument(ASyntacticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value, Location collectionLocation, IReadOnlyList<Location> elementLocations) => recorder.TryRecordConstructorArgument(parameterName, value, collectionLocation, elementLocations);
+    private static void TryRecordGenericArgument(ASyntacticArgumentRecorder recorder, ITypeParameterSymbol parameter, ITypeSymbol value, Location location) => recorder.TryRecordGenericArgument(parameter, value, location);
+    private static void TryRecordConstructorArgument(ASyntacticArgumentRecorder recorder, IParameterSymbol parameter, object? value, Location location) => recorder.TryRecordConstructorArgument(parameter, value, location);
+    private static void TryRecordConstructorArgument(ASyntacticArgumentRecorder recorder, IParameterSymbol parameter, IReadOnlyList<object?>? value, Location collectionLocation, IReadOnlyList<Location> elementLocations) => recorder.TryRecordConstructorArgument(parameter, value, collectionLocation, elementLocations);
     private static void TryRecordNamedArgument(ASyntacticArgumentRecorder recorder, string parameterName, object? value, Location location) => recorder.TryRecordNamedArgument(parameterName, value, location);
     private static void TryRecordNamedArgument(ASyntacticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value, Location collectionLocation, IReadOnlyList<Location> elementLocations) => recorder.TryRecordNamedArgument(parameterName, value, collectionLocation, elementLocations);
 
@@ -22,11 +22,11 @@ public class Comparer
 
         SyntacticArgumentRecorder recorder = new(comparer);
 
-        var parameterName = Datasets.GetValidParameterName();
+        var parameter = Datasets.GetMockedTypeParameter();
         var value = Datasets.GetValidTypeSymbol();
         var location = Datasets.GetValidLocation();
 
-        var exception = Record.Exception(() => TryRecordGenericArgument(recorder, parameterName, value, location));
+        var exception = Record.Exception(() => TryRecordGenericArgument(recorder, parameter, value, location));
 
         Assert.IsType<InvalidOperationException>(exception);
     }
@@ -38,11 +38,11 @@ public class Comparer
 
         SyntacticArgumentRecorder recorder = new(comparerMock.Object);
 
-        var parameterName = Datasets.GetValidParameterName();
+        var parameter = Datasets.GetMockedTypeParameter();
         var value = Datasets.GetValidTypeSymbol();
         var location = Datasets.GetValidLocation();
 
-        TryRecordGenericArgument(recorder, parameterName, value, location);
+        TryRecordGenericArgument(recorder, parameter, value, location);
 
         ComparerMock.VerifyInvoked(comparerMock);
     }
@@ -54,11 +54,11 @@ public class Comparer
 
         SyntacticArgumentRecorder recorder = new(comparerMock.Object);
 
-        var parameterName = Datasets.GetValidParameterName();
+        var parameter = Datasets.GetMockedParameter();
         var value = Datasets.GetValidTypeSymbol();
         var location = Datasets.GetValidLocation();
 
-        TryRecordConstructorArgument(recorder, parameterName, value, location);
+        TryRecordConstructorArgument(recorder, parameter, value, location);
 
         ComparerMock.VerifyInvoked(comparerMock);
     }
@@ -70,12 +70,12 @@ public class Comparer
 
         SyntacticArgumentRecorder recorder = new(comparerMock.Object);
 
-        var parameterName = Datasets.GetValidParameterName();
+        var parameter = Datasets.GetMockedParameter();
         var value = new[] { Datasets.GetValidTypeSymbol() };
         var collectionLocation = Datasets.GetValidLocation();
         var elementLocations = Datasets.GetValidElementLocations();
 
-        TryRecordConstructorArgument(recorder, parameterName, value, collectionLocation, elementLocations);
+        TryRecordConstructorArgument(recorder, parameter, value, collectionLocation, elementLocations);
 
         ComparerMock.VerifyInvoked(comparerMock);
     }

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/Datasets.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/Datasets.cs
@@ -12,6 +12,28 @@ internal static class Datasets
     public static string GetValidParameterName() => "Bar";
     public static string GetNullParameterName() => null!;
 
+    public static ITypeParameterSymbol GetMockedTypeParameter()
+    {
+        Mock<ITypeParameterSymbol> mock = new();
+
+        mock.SetupGet(static (parameter) => parameter.Name).Returns("Bar");
+
+        return mock.Object;
+    }
+
+    public static ITypeParameterSymbol GetNullTypeParameter() => null!;
+
+    public static IParameterSymbol GetMockedParameter()
+    {
+        Mock<IParameterSymbol> mock = new();
+
+        mock.SetupGet(static (parameter) => parameter.Name).Returns("Bar");
+
+        return mock.Object;
+    }
+
+    public static IParameterSymbol GetNullParameter() => null!;
+
     public static Location GetValidLocation() => Location.None;
     public static Location GetNullLocation() => null!;
 

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/TryRecordConstructorArgument_Array.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/TryRecordConstructorArgument_Array.cs
@@ -9,19 +9,19 @@ using Xunit;
 
 public class TryRecordConstructorArgument_Array
 {
-    private static bool Target(ASyntacticArgumentRecorder recorder, string parameterName, IReadOnlyList<object?>? value, Location collectionLocation, IReadOnlyList<Location> elementLocations) => recorder.TryRecordConstructorArgument(parameterName, value, collectionLocation, elementLocations);
+    private static bool Target(ASyntacticArgumentRecorder recorder, IParameterSymbol parameter, IReadOnlyList<object?>? value, Location collectionLocation, IReadOnlyList<Location> elementLocations) => recorder.TryRecordConstructorArgument(parameter, value, collectionLocation, elementLocations);
 
     [Fact]
     public void NullParameterName_ArgumentNullException()
     {
         SyntacticArgumentRecorder recorder = new(StringComparer.OrdinalIgnoreCase);
 
-        var parameterName = Datasets.GetNullParameterName();
+        var parameter = Datasets.GetNullParameter();
         var value = Datasets.GetValidArrayArgument();
         var collectionLocation = Datasets.GetValidLocation();
         var elementLocations = Datasets.GetValidElementLocations();
 
-        var exception = Record.Exception(() => Target(recorder, parameterName, value, collectionLocation, elementLocations));
+        var exception = Record.Exception(() => Target(recorder, parameter, value, collectionLocation, elementLocations));
 
         Assert.IsType<ArgumentNullException>(exception);
     }
@@ -33,12 +33,12 @@ public class TryRecordConstructorArgument_Array
 
         SyntacticArgumentRecorder recorder = new(comparerMock.Object);
 
-        var parameterName = Datasets.GetValidParameterName();
+        var parameter = Datasets.GetMockedParameter();
         var value = Datasets.GetValidArrayArgument();
         var collectionLocation = Datasets.GetNullLocation();
         var elementLocations = Datasets.GetValidElementLocations();
 
-        var exception = Record.Exception(() => Target(recorder, parameterName, value, collectionLocation, elementLocations));
+        var exception = Record.Exception(() => Target(recorder, parameter, value, collectionLocation, elementLocations));
 
         Assert.IsType<ArgumentNullException>(exception);
     }
@@ -50,12 +50,12 @@ public class TryRecordConstructorArgument_Array
 
         SyntacticArgumentRecorder recorder = new(comparerMock.Object);
 
-        var parameterName = Datasets.GetValidParameterName();
+        var parameter = Datasets.GetMockedParameter();
         var value = Datasets.GetValidArrayArgument();
         var collectionLocation = Datasets.GetValidLocation();
         var elementLocations = Datasets.GetNullElementLocations();
 
-        var exception = Record.Exception(() => Target(recorder, parameterName, value, collectionLocation, elementLocations));
+        var exception = Record.Exception(() => Target(recorder, parameter, value, collectionLocation, elementLocations));
 
         Assert.IsType<ArgumentNullException>(exception);
     }
@@ -67,12 +67,12 @@ public class TryRecordConstructorArgument_Array
 
         SyntacticArgumentRecorder recorder = new(comparerMock.Object);
 
-        var parameterName = Datasets.GetValidParameterName();
+        var parameter = Datasets.GetMockedParameter();
         var value = Datasets.GetNullArrayArgument();
         var collectionLocation = Datasets.GetValidLocation();
         var elementLocations = Datasets.GetValidElementLocations();
 
-        var actual = Target(recorder, parameterName, value, collectionLocation, elementLocations);
+        var actual = Target(recorder, parameter, value, collectionLocation, elementLocations);
 
         Assert.True(actual);
 
@@ -88,12 +88,12 @@ public class TryRecordConstructorArgument_Array
 
         SyntacticArgumentRecorder recorder = new(comparerMock.Object);
 
-        var parameterName = Datasets.GetValidParameterName();
+        var parameter = Datasets.GetMockedParameter();
         var value = Datasets.GetValidArrayArgument();
         var collectionLocation = Datasets.GetValidLocation();
         var elementLocations = Datasets.GetValidElementLocations();
 
-        var actual = Target(recorder, parameterName, value, collectionLocation, elementLocations);
+        var actual = Target(recorder, parameter, value, collectionLocation, elementLocations);
 
         Assert.True(actual);
 
@@ -109,12 +109,12 @@ public class TryRecordConstructorArgument_Array
 
         SyntacticArgumentRecorder recorder = new(comparerMock.Object);
 
-        var parameterName = Datasets.GetValidParameterName();
+        var parameter = Datasets.GetMockedParameter();
         var value = Datasets.GetValidArrayArgument();
         var collectionLocation = Datasets.GetValidLocation();
         var elementLocations = Datasets.GetValidElementLocations();
 
-        var actual = Target(recorder, parameterName, value, collectionLocation, elementLocations);
+        var actual = Target(recorder, parameter, value, collectionLocation, elementLocations);
 
         Assert.False(actual);
 

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/TryRecordConstructorArgument_Single.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/TryRecordConstructorArgument_Single.cs
@@ -8,18 +8,18 @@ using Xunit;
 
 public class TryRecordConstructorArgument_Single
 {
-    private static bool Target(ASyntacticArgumentRecorder recorder, string parameterName, object? value, Location location) => recorder.TryRecordConstructorArgument(parameterName, value, location);
+    private static bool Target(ASyntacticArgumentRecorder recorder, IParameterSymbol parameter, object? value, Location location) => recorder.TryRecordConstructorArgument(parameter, value, location);
 
     [Fact]
     public void NullParameterName_ArgumentNullException()
     {
         SyntacticArgumentRecorder recorder = new(StringComparer.OrdinalIgnoreCase);
 
-        var parameterName = Datasets.GetNullParameterName();
+        var parameter = Datasets.GetNullParameter();
         var value = Datasets.GetValidTypeSymbol();
         var location = Datasets.GetValidLocation();
 
-        var exception = Record.Exception(() => Target(recorder, parameterName, value, location));
+        var exception = Record.Exception(() => Target(recorder, parameter, value, location));
 
         Assert.IsType<ArgumentNullException>(exception);
     }
@@ -31,11 +31,11 @@ public class TryRecordConstructorArgument_Single
 
         SyntacticArgumentRecorder recorder = new(comparerMock.Object);
 
-        var parameterName = Datasets.GetValidParameterName();
+        var parameter = Datasets.GetMockedParameter();
         var value = Datasets.GetValidTypeSymbol();
         var location = Datasets.GetNullLocation();
 
-        var exception = Record.Exception(() => Target(recorder, parameterName, value, location));
+        var exception = Record.Exception(() => Target(recorder, parameter, value, location));
 
         Assert.IsType<ArgumentNullException>(exception);
     }
@@ -47,11 +47,11 @@ public class TryRecordConstructorArgument_Single
 
         SyntacticArgumentRecorder recorder = new(comparerMock.Object);
 
-        var parameterName = Datasets.GetValidParameterName();
+        var parameter = Datasets.GetMockedParameter();
         var value = Datasets.GetNullTypeSymbol();
         var location = Datasets.GetValidLocation();
 
-        var actual = Target(recorder, parameterName, value, location);
+        var actual = Target(recorder, parameter, value, location);
 
         Assert.True(actual);
 
@@ -66,11 +66,11 @@ public class TryRecordConstructorArgument_Single
 
         SyntacticArgumentRecorder recorder = new(comparerMock.Object);
 
-        var parameterName = Datasets.GetValidParameterName();
+        var parameter = Datasets.GetMockedParameter();
         var value = Datasets.GetValidTypeSymbol();
         var location = Datasets.GetValidLocation();
 
-        var actual = Target(recorder, parameterName, value, location);
+        var actual = Target(recorder, parameter, value, location);
 
         Assert.True(actual);
 
@@ -85,11 +85,11 @@ public class TryRecordConstructorArgument_Single
 
         SyntacticArgumentRecorder recorder = new(comparerMock.Object);
 
-        var parameterName = Datasets.GetValidParameterName();
+        var parameter = Datasets.GetMockedParameter();
         var value = Datasets.GetValidTypeSymbol();
         var location = Datasets.GetValidLocation();
 
-        var actual = Target(recorder, parameterName, value, location);
+        var actual = Target(recorder, parameter, value, location);
 
         Assert.False(actual);
 

--- a/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/TryRecordGenericArgument.cs
+++ b/src/SharpAttributeParser.Tests/ASyntacticArgumentRecorderCases/TryRecordGenericArgument.cs
@@ -8,18 +8,18 @@ using Xunit;
 
 public class TryRecordGenericArgument
 {
-    private static bool Target(ASyntacticArgumentRecorder recorder, string parameterName, ITypeSymbol value, Location location) => recorder.TryRecordGenericArgument(parameterName, value, location);
+    private static bool Target(ASyntacticArgumentRecorder recorder, ITypeParameterSymbol parameter, ITypeSymbol value, Location location) => recorder.TryRecordGenericArgument(parameter, value, location);
 
     [Fact]
     public void NullParameterName_ArgumentNullException()
     {
         SyntacticArgumentRecorder recorder = new(StringComparer.OrdinalIgnoreCase);
 
-        var parameterName = Datasets.GetNullParameterName();
+        var parameter = Datasets.GetNullTypeParameter();
         var value = Datasets.GetValidTypeSymbol();
         var location = Datasets.GetValidLocation();
 
-        var exception = Record.Exception(() => Target(recorder, parameterName, value, location));
+        var exception = Record.Exception(() => Target(recorder, parameter, value, location));
 
         Assert.IsType<ArgumentNullException>(exception);
     }
@@ -29,11 +29,11 @@ public class TryRecordGenericArgument
     {
         SyntacticArgumentRecorder recorder = new(StringComparer.OrdinalIgnoreCase);
 
-        var parameterName = Datasets.GetValidParameterName();
+        var parameter = Datasets.GetMockedTypeParameter();
         var value = Datasets.GetNullTypeSymbol();
         var location = Datasets.GetValidLocation();
 
-        var exception = Record.Exception(() => Target(recorder, parameterName, value, location));
+        var exception = Record.Exception(() => Target(recorder, parameter, value, location));
 
         Assert.IsType<ArgumentNullException>(exception);
     }
@@ -43,11 +43,11 @@ public class TryRecordGenericArgument
     {
         SyntacticArgumentRecorder recorder = new(StringComparer.OrdinalIgnoreCase);
 
-        var parameterName = Datasets.GetValidParameterName();
+        var parameter = Datasets.GetMockedTypeParameter();
         var value = Datasets.GetValidTypeSymbol();
         var location = Datasets.GetNullLocation();
 
-        var exception = Record.Exception(() => Target(recorder, parameterName, value, location));
+        var exception = Record.Exception(() => Target(recorder, parameter, value, location));
 
         Assert.IsType<ArgumentNullException>(exception);
     }
@@ -59,11 +59,11 @@ public class TryRecordGenericArgument
 
         SyntacticArgumentRecorder recorder = new(comparerMock.Object);
 
-        var parameterName = Datasets.GetValidParameterName();
+        var parameter = Datasets.GetMockedTypeParameter();
         var value = Datasets.GetValidTypeSymbol();
         var location = Datasets.GetValidLocation();
 
-        var actual = Target(recorder, parameterName, value, location);
+        var actual = Target(recorder, parameter, value, location);
 
         Assert.True(actual);
 
@@ -78,11 +78,11 @@ public class TryRecordGenericArgument
 
         SyntacticArgumentRecorder recorder = new(comparerMock.Object);
 
-        var parameterName = Datasets.GetValidParameterName();
+        var parameter = Datasets.GetMockedTypeParameter();
         var value = Datasets.GetValidTypeSymbol();
         var location = Datasets.GetValidLocation();
 
-        var actual = Target(recorder, parameterName, value, location);
+        var actual = Target(recorder, parameter, value, location);
 
         Assert.False(actual);
 

--- a/src/SharpAttributeParser.Tests/ExampleCases.cs
+++ b/src/SharpAttributeParser.Tests/ExampleCases.cs
@@ -1,0 +1,68 @@
+﻿namespace SharpAttributeParser.Tests;
+
+using Microsoft.CodeAnalysis;
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using Xunit;
+
+public class ExampleCases
+{
+    private static bool Target(ISemanticAttributeParser parser, ISemanticArgumentRecorder recorder, AttributeData attributeData) => parser.TryParse(recorder, attributeData);
+
+    [Fact]
+    public async Task CorrectlyParsed()
+    {
+        var source = """
+            [Example<System.Type>(new[] { 0, 1, 1, 2 }, name: "Fib", Answer = 41 + 1)]
+            public class Foo { }
+            """;
+
+        var parser = DependencyInjection.GetRequiredService<ISemanticAttributeParser>();
+
+        ExampleRecorder recorder = new();
+
+        var (compilation, attributeData, _) = await CompilationStore.GetComponents(source, "Foo");
+
+        var typeType = compilation.GetTypeByMetadataName("System.Type");
+
+        var actual = Target(parser, recorder, attributeData);
+
+        Assert.True(actual);
+
+        Assert.Equal(typeType, recorder.T);
+        Assert.Equal(new[] { 0, 1, 1, 2 }, recorder.Sequence);
+        Assert.Equal("Fib", recorder.Name);
+        Assert.Equal(42, recorder.Answer);
+    }
+
+    private sealed class ExampleRecorder : ASemanticArgumentRecorder
+    {
+        public ITypeSymbol T { get; set; } = null!;
+        public IReadOnlyList<int> Sequence { get; set; } = null!;
+        public string Name { get; set; } = null!;
+        public int? Answer { get; set; }
+
+        protected override IEnumerable<(string, DSemanticGenericRecorder)> AddGenericRecorders()
+        {
+            yield return ("T", Adapters.For(RecordT));
+        }
+
+        protected override IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders()
+        {
+            yield return ("Sequence", Adapters.For<int>(RecordSequence));
+        }
+
+        protected override IEnumerable<(string, DSemanticSingleRecorder)> AddSingleRecorders()
+        {
+            yield return ("Name", Adapters.For<string>(RecordName));
+            yield return ("Answer", Adapters.For<int>(RecordAnswer));
+        }
+
+        private void RecordT(ITypeSymbol t) => T = t;
+        private void RecordSequence(IReadOnlyList<int> sequence) => Sequence = sequence;
+        private void RecordName(string name) => Name = name;
+        private void RecordAnswer(int answer) => Answer = answer;
+    }
+}

--- a/src/SharpAttributeParser.Tests/ISemanticAttributeParserCases/TryParse.cs
+++ b/src/SharpAttributeParser.Tests/ISemanticAttributeParserCases/TryParse.cs
@@ -103,7 +103,7 @@ public class TryParse
     {
         Mock<ISemanticArgumentRecorder> recorderMock = new();
 
-        recorderMock.Setup(static (recorder) => recorder.TryRecordGenericArgument(It.IsAny<string>(), It.IsAny<ITypeSymbol>())).Returns(false);
+        recorderMock.Setup(static (recorder) => recorder.TryRecordGenericArgument(It.IsAny<ITypeParameterSymbol>(), It.IsAny<ITypeSymbol>())).Returns(false);
 
         var source = """
             [Generic<string>]
@@ -196,7 +196,7 @@ public class TryParse
     {
         Mock<ISemanticArgumentRecorder> recorderMock = new();
 
-        recorderMock.Setup(static (recorder) => recorder.TryRecordConstructorArgument(It.IsAny<string>(), It.IsAny<object?>())).Returns(false);
+        recorderMock.Setup(static (recorder) => recorder.TryRecordConstructorArgument(It.IsAny<IParameterSymbol>(), It.IsAny<object?>())).Returns(false);
 
         var source = """
             [SingleConstructor(null)]
@@ -257,7 +257,7 @@ public class TryParse
     {
         Mock<ISemanticArgumentRecorder> recorderMock = new();
 
-        recorderMock.Setup(static (recorder) => recorder.TryRecordConstructorArgument(It.IsAny<string>(), It.IsAny<IReadOnlyList<object?>?>())).Returns(false);
+        recorderMock.Setup(static (recorder) => recorder.TryRecordConstructorArgument(It.IsAny<IParameterSymbol>(), It.IsAny<IReadOnlyList<object?>?>())).Returns(false);
 
         var source = """
             [ArrayConstructor(null)]

--- a/src/SharpAttributeParser.Tests/ISyntacticAttributeParserCases/TryParse.cs
+++ b/src/SharpAttributeParser.Tests/ISyntacticAttributeParserCases/TryParse.cs
@@ -129,7 +129,7 @@ public class TryParse
     {
         Mock<ISyntacticArgumentRecorder> recorderMock = new();
 
-        recorderMock.Setup(static (recorder) => recorder.TryRecordGenericArgument(It.IsAny<string>(), It.IsAny<ITypeSymbol>(), It.IsAny<Location>())).Returns(false);
+        recorderMock.Setup(static (recorder) => recorder.TryRecordGenericArgument(It.IsAny<ITypeParameterSymbol>(), It.IsAny<ITypeSymbol>(), It.IsAny<Location>())).Returns(false);
 
         var source = """
             [Generic<string>]
@@ -227,7 +227,7 @@ public class TryParse
     {
         Mock<ISyntacticArgumentRecorder> recorderMock = new();
 
-        recorderMock.Setup(static (recorder) => recorder.TryRecordConstructorArgument(It.IsAny<string>(), It.IsAny<object?>(), It.IsAny<Location>())).Returns(false);
+        recorderMock.Setup(static (recorder) => recorder.TryRecordConstructorArgument(It.IsAny<IParameterSymbol>(), It.IsAny<object?>(), It.IsAny<Location>())).Returns(false);
 
         var source = """
             [SingleConstructor(null)]
@@ -319,7 +319,7 @@ public class TryParse
     {
         Mock<ISyntacticArgumentRecorder> recorderMock = new();
 
-        recorderMock.Setup(static (recorder) => recorder.TryRecordConstructorArgument(It.IsAny<string>(), It.IsAny<IReadOnlyList<object?>?>(), It.IsAny<Location>(), It.IsAny<IReadOnlyList<Location>>())).Returns(false);
+        recorderMock.Setup(static (recorder) => recorder.TryRecordConstructorArgument(It.IsAny<IParameterSymbol>(), It.IsAny<IReadOnlyList<object?>?>(), It.IsAny<Location>(), It.IsAny<IReadOnlyList<Location>>())).Returns(false);
 
         var source = """
             [ArrayConstructor(null)]

--- a/src/SharpAttributeParser.Tests/TestAttributes/ExampleAttribute.cs
+++ b/src/SharpAttributeParser.Tests/TestAttributes/ExampleAttribute.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+
+[AttributeUsage(AttributeTargets.Class)]
+[SuppressMessage("Design", "CA1050: Declare types in namespaces")]
+[SuppressMessage("Major Code Smell", "S2326: Unused type parameters should be removed", Justification = "Used when parsing the attribute.")]
+[SuppressMessage("Major Bug", "S3903: Types should be defined in named namespaces")]
+public sealed class ExampleAttribute<T> : Attribute
+{
+    public int[] Sequence { get; }
+    public string Name { get; }
+
+    public int Answer { get; set; }
+
+    public ExampleAttribute(int[] sequence, string name)
+    {
+        Sequence = sequence;
+        Name = name;
+    }
+}

--- a/src/SharpAttributeParser/AArgumentRecorder.cs
+++ b/src/SharpAttributeParser/AArgumentRecorder.cs
@@ -15,13 +15,13 @@ using System.Collections.Generic;
 public abstract class AArgumentRecorder : ASyntacticArgumentRecorder, ISemanticArgumentRecorder
 {
     /// <inheritdoc/>
-    public bool TryRecordGenericArgument(string parameterName, ITypeSymbol value) => TryRecordGenericArgument(parameterName, value, Location.None);
+    public bool TryRecordGenericArgument(ITypeParameterSymbol parameter, ITypeSymbol value) => TryRecordGenericArgument(parameter, value, Location.None);
 
     /// <inheritdoc/>
-    public bool TryRecordConstructorArgument(string parameterName, object? value) => TryRecordConstructorArgument(parameterName, value, Location.None);
+    public bool TryRecordConstructorArgument(IParameterSymbol parameter, object? value) => TryRecordConstructorArgument(parameter, value, Location.None);
 
     /// <inheritdoc/>
-    public bool TryRecordConstructorArgument(string parameterName, IReadOnlyList<object?>? value) => TryRecordConstructorArgument(parameterName, value, Location.None, Array.Empty<Location>());
+    public bool TryRecordConstructorArgument(IParameterSymbol parameter, IReadOnlyList<object?>? value) => TryRecordConstructorArgument(parameter, value, Location.None, Array.Empty<Location>());
 
     /// <inheritdoc/>
     public bool TryRecordNamedArgument(string parameterName, object? value) => TryRecordNamedArgument(parameterName, value, Location.None);

--- a/src/SharpAttributeParser/ASemanticArgumentRecorder.cs
+++ b/src/SharpAttributeParser/ASemanticArgumentRecorder.cs
@@ -92,16 +92,16 @@ public abstract class ASemanticArgumentRecorder : ISemanticArgumentRecorder
     protected virtual IEnumerable<(string, DSemanticArrayRecorder)> AddArrayRecorders() => Array.Empty<(string, DSemanticArrayRecorder)>();
 
     /// <inheritdoc/>
-    public bool TryRecordGenericArgument(string parameterName, ITypeSymbol value)
+    public bool TryRecordGenericArgument(ITypeParameterSymbol parameter, ITypeSymbol value)
     {
         if (IsInitialized is false)
         {
             InitializeRecorder();
         }
 
-        if (parameterName is null)
+        if (parameter is null)
         {
-            throw new ArgumentNullException(nameof(parameterName));
+            throw new ArgumentNullException(nameof(parameter));
         }
 
         if (value is null)
@@ -109,7 +109,7 @@ public abstract class ASemanticArgumentRecorder : ISemanticArgumentRecorder
             throw new ArgumentNullException(nameof(value));
         }
 
-        if (GenericRecorders.TryGetValue(parameterName, out var recorder) is false || recorder is null)
+        if (GenericRecorders.TryGetValue(parameter.Name, out var recorder) is false || recorder is null)
         {
             return false;
         }
@@ -118,7 +118,29 @@ public abstract class ASemanticArgumentRecorder : ISemanticArgumentRecorder
     }
 
     /// <inheritdoc/>
-    public bool TryRecordConstructorArgument(string parameterName, object? value)
+    public bool TryRecordConstructorArgument(IParameterSymbol parameter, object? value)
+    {
+        if (parameter is null)
+        {
+            throw new ArgumentNullException(nameof(parameter));
+        }
+
+        return TryRecordNamedArgument(parameter.Name, value);
+    }
+
+    /// <inheritdoc/>
+    public bool TryRecordConstructorArgument(IParameterSymbol parameter, IReadOnlyList<object?>? value)
+    {
+        if (parameter is null)
+        {
+            throw new ArgumentNullException(nameof(parameter));
+        }
+
+        return TryRecordNamedArgument(parameter.Name, value);
+    }
+
+    /// <inheritdoc/>
+    public bool TryRecordNamedArgument(string parameterName, object? value)
     {
         if (IsInitialized is false)
         {
@@ -141,7 +163,7 @@ public abstract class ASemanticArgumentRecorder : ISemanticArgumentRecorder
     }
 
     /// <inheritdoc/>
-    public bool TryRecordConstructorArgument(string parameterName, IReadOnlyList<object?>? value)
+    public bool TryRecordNamedArgument(string parameterName, IReadOnlyList<object?>? value)
     {
         if (IsInitialized is false)
         {
@@ -162,10 +184,4 @@ public abstract class ASemanticArgumentRecorder : ISemanticArgumentRecorder
 
         return recorder(value);
     }
-
-    /// <inheritdoc/>
-    public bool TryRecordNamedArgument(string parameterName, object? value) => TryRecordConstructorArgument(parameterName, value);
-
-    /// <inheritdoc/>
-    public bool TryRecordNamedArgument(string parameterName, IReadOnlyList<object?>? value) => TryRecordConstructorArgument(parameterName, value);
 }

--- a/src/SharpAttributeParser/ASyntacticArgumentRecorder.cs
+++ b/src/SharpAttributeParser/ASyntacticArgumentRecorder.cs
@@ -95,16 +95,16 @@ public abstract class ASyntacticArgumentRecorder : ISyntacticArgumentRecorder
     protected virtual IEnumerable<(string, DSyntacticArrayRecorder)> AddArrayRecorders() => Array.Empty<(string, DSyntacticArrayRecorder)>();
 
     /// <inheritdoc/>
-    public bool TryRecordGenericArgument(string parameterName, ITypeSymbol value, Location location)
+    public bool TryRecordGenericArgument(ITypeParameterSymbol parameter, ITypeSymbol value, Location location)
     {
         if (IsInitialized is false)
         {
             InitializeRecorder();
         }
 
-        if (parameterName is null)
+        if (parameter is null)
         {
-            throw new ArgumentNullException(nameof(parameterName));
+            throw new ArgumentNullException(nameof(parameter));
         }
 
         if (value is null)
@@ -119,7 +119,7 @@ public abstract class ASyntacticArgumentRecorder : ISyntacticArgumentRecorder
 
         var recorders = GenericRecorders;
 
-        if (recorders is null || recorders.TryGetValue(parameterName, out var recorder) is false || recorder is null)
+        if (recorders is null || recorders.TryGetValue(parameter.Name, out var recorder) is false || recorder is null)
         {
             return false;
         }
@@ -128,7 +128,29 @@ public abstract class ASyntacticArgumentRecorder : ISyntacticArgumentRecorder
     }
 
     /// <inheritdoc/>
-    public bool TryRecordConstructorArgument(string parameterName, object? value, Location location)
+    public bool TryRecordConstructorArgument(IParameterSymbol parameter, object? value, Location location)
+    {
+        if (parameter is null)
+        {
+            throw new ArgumentNullException(nameof(parameter));
+        }
+
+        return TryRecordNamedArgument(parameter.Name, value, location);
+    }
+
+    /// <inheritdoc/>
+    public bool TryRecordConstructorArgument(IParameterSymbol parameter, IReadOnlyList<object?>? value, Location collectionLocation, IReadOnlyList<Location> elementLocations)
+    {
+        if (parameter is null)
+        {
+            throw new ArgumentNullException(nameof(parameter));
+        }
+
+        return TryRecordNamedArgument(parameter.Name, value, collectionLocation, elementLocations);
+    }
+
+    /// <inheritdoc/>
+    public bool TryRecordNamedArgument(string parameterName, object? value, Location location)
     {
         if (IsInitialized is false)
         {
@@ -156,7 +178,7 @@ public abstract class ASyntacticArgumentRecorder : ISyntacticArgumentRecorder
     }
 
     /// <inheritdoc/>
-    public bool TryRecordConstructorArgument(string parameterName, IReadOnlyList<object?>? value, Location collectionLocation, IReadOnlyList<Location> elementLocations)
+    public bool TryRecordNamedArgument(string parameterName, IReadOnlyList<object?>? value, Location collectionLocation, IReadOnlyList<Location> elementLocations)
     {
         if (IsInitialized is false)
         {
@@ -187,10 +209,4 @@ public abstract class ASyntacticArgumentRecorder : ISyntacticArgumentRecorder
 
         return recorder(value, collectionLocation, elementLocations);
     }
-
-    /// <inheritdoc/>
-    public bool TryRecordNamedArgument(string parameterName, object? value, Location location) => TryRecordConstructorArgument(parameterName, value, location);
-
-    /// <inheritdoc/>
-    public bool TryRecordNamedArgument(string parameterName, IReadOnlyList<object?>? value, Location collectionLocation, IReadOnlyList<Location> elementLocations) => TryRecordConstructorArgument(parameterName, value, collectionLocation, elementLocations);
 }

--- a/src/SharpAttributeParser/SemanticAttributeParser.cs
+++ b/src/SharpAttributeParser/SemanticAttributeParser.cs
@@ -53,7 +53,7 @@ public sealed class SemanticAttributeParser : ISemanticAttributeParser
 
         for (var i = 0; i < attributeType.TypeArguments.Length; i++)
         {
-            if (recorder.TryRecordGenericArgument(attributeType.TypeParameters[i].Name, attributeType.TypeArguments[i]) is false)
+            if (recorder.TryRecordGenericArgument(attributeType.TypeParameters[i], attributeType.TypeArguments[i]) is false)
             {
                 return false;
             }
@@ -88,7 +88,7 @@ public sealed class SemanticAttributeParser : ISemanticAttributeParser
 
             if (i == attributeConstructor.Parameters.Count() - 1 && attributeConstructor.Parameters.Count() < attributeData.ConstructorArguments.Length)
             {
-                if (recorder.TryRecordConstructorArgument(attributeConstructor.Parameters[i].Name, CommonAttributeParsing.ArrayArguments(attributeData.ConstructorArguments[i])) is false)
+                if (recorder.TryRecordConstructorArgument(attributeConstructor.Parameters[i], CommonAttributeParsing.ArrayArguments(attributeData.ConstructorArguments[i])) is false)
                 {
                     return false;
                 }
@@ -98,7 +98,7 @@ public sealed class SemanticAttributeParser : ISemanticAttributeParser
 
             if (attributeData.ConstructorArguments[i].Kind is TypedConstantKind.Array)
             {
-                if (recorder.TryRecordConstructorArgument(attributeConstructor.Parameters[i].Name, CommonAttributeParsing.ArrayArguments(attributeData.ConstructorArguments[i])) is false)
+                if (recorder.TryRecordConstructorArgument(attributeConstructor.Parameters[i], CommonAttributeParsing.ArrayArguments(attributeData.ConstructorArguments[i])) is false)
                 {
                     return false;
                 }
@@ -106,7 +106,7 @@ public sealed class SemanticAttributeParser : ISemanticAttributeParser
                 continue;
             }
 
-            if (recorder.TryRecordConstructorArgument(attributeConstructor.Parameters[i].Name, CommonAttributeParsing.SingleArgument(attributeData.ConstructorArguments[i])) is false)
+            if (recorder.TryRecordConstructorArgument(attributeConstructor.Parameters[i], CommonAttributeParsing.SingleArgument(attributeData.ConstructorArguments[i])) is false)
             {
                 return false;
             }

--- a/src/SharpAttributeParser/SyntacticAttributeParser.cs
+++ b/src/SharpAttributeParser/SyntacticAttributeParser.cs
@@ -81,7 +81,7 @@ public sealed class SyntacticAttributeParser : ISyntacticAttributeParser
         {
             var location = ArgumentLocator.TypeArgument(genericNameSyntax.TypeArgumentList.Arguments[i]);
 
-            if (recorder.TryRecordGenericArgument(attributeType.TypeParameters[i].Name, attributeType.TypeArguments[i], location) is false)
+            if (recorder.TryRecordGenericArgument(attributeType.TypeParameters[i], attributeType.TypeArguments[i], location) is false)
             {
                 return false;
             }
@@ -133,7 +133,7 @@ public sealed class SyntacticAttributeParser : ISyntacticAttributeParser
 
                 var (collectionLocation, elementLocations) = ArgumentLocator.ArrayArgument(attributeSyntax.ArgumentList.Arguments[i].Expression);
 
-                if (recorder.TryRecordConstructorArgument(attributeConstructor.Parameters[i].Name, CommonAttributeParsing.ArrayArguments(attributeData.ConstructorArguments[i]), collectionLocation, elementLocations) is false)
+                if (recorder.TryRecordConstructorArgument(attributeConstructor.Parameters[i], CommonAttributeParsing.ArrayArguments(attributeData.ConstructorArguments[i]), collectionLocation, elementLocations) is false)
                 {
                     return false;
                 }
@@ -143,7 +143,7 @@ public sealed class SyntacticAttributeParser : ISyntacticAttributeParser
 
             var location = ArgumentLocator.SingleArgument(attributeSyntax.ArgumentList.Arguments[i].Expression);
 
-            if (recorder.TryRecordConstructorArgument(attributeConstructor.Parameters[i].Name, CommonAttributeParsing.SingleArgument(attributeData.ConstructorArguments[i]), location) is false)
+            if (recorder.TryRecordConstructorArgument(attributeConstructor.Parameters[i], CommonAttributeParsing.SingleArgument(attributeData.ConstructorArguments[i]), location) is false)
             {
                 return false;
             }
@@ -168,7 +168,7 @@ public sealed class SyntacticAttributeParser : ISyntacticAttributeParser
 
         var (paramsCollectionLocation, paramsElementLocations) = ArgumentLocator.ParamsArguments(attributeSyntax.ArgumentList.Arguments.Skip(index).Take(attributeSyntax.ArgumentList.Arguments.Count - (attributeData.ConstructorArguments.Length + attributeData.NamedArguments.Length) + 1).Select(static (argument) => argument.Expression).ToArray());
 
-        return recorder.TryRecordConstructorArgument(attributeConstructor.Parameters[index].Name, CommonAttributeParsing.ArrayArguments(attributeData.ConstructorArguments[index]), paramsCollectionLocation, paramsElementLocations);
+        return recorder.TryRecordConstructorArgument(attributeConstructor.Parameters[index], CommonAttributeParsing.ArrayArguments(attributeData.ConstructorArguments[index]), paramsCollectionLocation, paramsElementLocations);
     }
 
     private bool TryParseNamedArguments(ISyntacticArgumentRecorder recorder, AttributeData attributeData, AttributeSyntax attributeSyntax)


### PR DESCRIPTION
Recorders preserve symbols, rather than prematurely reducing to string names. Abstract base-clases still only exposes strings.